### PR TITLE
ci(deploy): fix false-failure on non-image pushes + guard rollback

### DIFF
--- a/.github/workflows/deploy-simple.yaml
+++ b/.github/workflows/deploy-simple.yaml
@@ -17,11 +17,17 @@
 name: Deploy Makalu Explorer (vps1)
 
 on:
+  # Trigger ONLY on image-producing changes — these are the exact paths that
+  # publish-images.yaml builds from. A workflow/doc-only change does NOT publish
+  # an image, so triggering a deploy on it would wait forever for a sha image
+  # that never gets built (and then needlessly roll back). Use workflow_dispatch
+  # to deploy a commit manually.
   push:
     branches: [main]
     paths:
-      - 'Makalu/**'
-      - '.github/workflows/deploy-simple.yaml'
+      - 'Makalu/api/**'
+      - 'Makalu/indexer/**'
+      - 'Makalu/explorer/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -46,6 +52,11 @@ jobs:
   deploy:
     name: Deploy to vps1
     runs-on: ubuntu-latest
+    outputs:
+      # "true" once we get past the image-wait and actually touch vps1. Gates the
+      # rollback job so a wait-for-images failure (nothing deployed) does NOT
+      # trigger a needless rollback/restart of the live site.
+      deployed: ${{ steps.deploy.outputs.deployed }}
     environment:
       name: ${{ github.event.inputs.environment || 'mainnet' }}
       url: https://makalu.litho.ai
@@ -86,7 +97,10 @@ jobs:
       # pull + `up -d` web/api logic (compose/.env preserved) lives in that host
       # script. See litho-validator-infra docs/MAKALU_STATE_AND_DEPLOY_HANDOFF.md.
       - name: Deploy to vps1 (pull + recreate, compose preserved)
-        run: ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes "$VPS_USER@$VPS_HOST" deploy
+        id: deploy
+        run: |
+          echo "deployed=true" >> "$GITHUB_OUTPUT"   # mark: we are now mutating vps1
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes "$VPS_USER@$VPS_HOST" deploy
 
       # The step the old pipeline lacked: verify the change is live on the PUBLIC
       # URL (not just containers healthy on a host). Retries to cover publish/deploy lag.
@@ -121,7 +135,9 @@ jobs:
     name: Rollback on failure
     runs-on: ubuntu-latest
     needs: deploy
-    if: failure()
+    # Only roll back if we actually deployed (got past the image-wait). A
+    # wait-for-images failure means nothing changed on vps1 — nothing to revert.
+    if: failure() && needs.deploy.outputs.deployed == 'true'
     steps:
       - name: Setup SSH to vps1
         run: |


### PR DESCRIPTION
## Why
The PR #18 merge deploy run **failed at "Wait for published images (sha-1ee8c5e)"**. Root cause: that merge commit only changed the **workflow file**, but `publish-images.yaml` only builds on `Makalu/{api,indexer,explorer}/**`. So no `sha-1ee8c5e` image was ever published, the wait timed out, and the **rollback job then fired needlessly** (a no-op — `:previous` == `:mainnet` == `4a92662`, so the live site was unaffected, but it's noise).

## Fix
1. **Trigger deploy only on image-producing paths** — `Makalu/api/**`, `Makalu/indexer/**`, `Makalu/explorer/**` (exactly what `publish-images.yaml` builds) + `workflow_dispatch`. Removed the broad `Makalu/**` and the workflow self-trigger that caused this.
2. **Guard the rollback** — it now runs only if `needs.deploy.outputs.deployed == 'true'` (set once we pass the image-wait and actually touch vps1). A wait-for-images failure means nothing changed on vps1, so there's nothing to revert.

No change to the vps1 deploy mechanism / hardened key. `makalu.litho.ai` is unaffected (still serving `4a92662`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)