### PR TITLE
perf(api): speed up /txs and homepage transaction loading

### DIFF
--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -56,8 +56,8 @@ const EVM_RPC_URL = (process.env.EVM_RPC_URL || '').replace(/\/$/, '');
 const PUBLIC_EVM_RPC_URL = (process.env.PUBLIC_EVM_RPC_URL || 'https://rpc.litho.ai').replace(/\/$/, '');
 const EVM_RPC_ENDPOINTS = [...new Set([EVM_RPC_URL, RPC_URL, PUBLIC_EVM_RPC_URL].filter(Boolean))];
 const COUNT_CACHE_TTL_MS = 10_000;
-const STATS_SUMMARY_TTL_MS = 5_000;
-const EVM_ENRICH_TTL_MS = 60_000;
+const STATS_SUMMARY_TTL_MS = 15_000;
+const EVM_ENRICH_TTL_MS = 600_000;
 const MAX_RUNTIME_CACHE_ENTRIES = 2_000;
 
 interface CacheEntry<T> {
@@ -1521,8 +1521,8 @@ export function explorerRouter(): Router {
         getCachedCount('transactions-total', 'SELECT COUNT(*) AS count FROM transactions'),
       ]);
 
-      const baseRows = await Promise.all(rows.map(async (row) => {
-        let evmExtra: EvmExtra = {
+      const baseRows = rows.map((row) => {
+        const evmExtra: EvmExtra = {
           input_data: row.evm_input_data,
           contract_address: row.evm_contract_address,
           from_address: row.evm_from_address,
@@ -1531,9 +1531,8 @@ export function explorerRouter(): Router {
           gas_price: row.evm_gas_price,
           nonce: row.evm_nonce,
         };
-        if (row.evm_hash) evmExtra = await enrichEvmFromRpc(row.evm_hash, evmExtra);
         return mapTx(row, row.evm_hash, evmExtra);
-      }));
+      });
       const enrichedRows = await enrichTokenInfoBatch(baseRows);
 
       res.json({
@@ -2107,7 +2106,7 @@ export function explorerRouter(): Router {
         getTokenTransferIndexStatus(),
       ]);
       const tokenStatsByAddress = tokenTransferIndex.ready
-        ? await getTokenStatsByContract()
+        ? await loadCached('token-stats-by-contract', 30_000, getTokenStatsByContract)
         : new Map<string, { holders: number; transfers: number }>();
 
       const visibleContractTokens = contractTokens.filter((token) => !isHiddenToken(token));


### PR DESCRIPTION
## Problem
Transactions on the homepage and `/txs` loaded slowly.

## Root causes & fixes
1. **`/txs` list made 25 parallel EVM RPC calls per request.** Each row triggered `enrichEvmFromRpc` (`eth_getTransactionByHash`, 10s timeout). All data the list needs (from, to, value, method) is already in the `evm_transactions` JOIN, so the RPC was wasted work. Replaced the `Promise.all` of async RPC calls with a plain sync `.map()`.
2. **`/stats/summary` cache TTL (5s) was shorter than the 6s poll interval**, so nearly every homepage poll busted the cache and re-ran `fetchChainTipHeight()` (Cosmos RPC) + a heavy inconsistent-blocks CTE. Bumped to 15s.
3. **`/tokens` ran an expensive token-transfer CTE on every 6s poll** with no cache. Wrapped `getTokenStatsByContract()` in `loadCached(30s)`.
4. **`EVM_ENRICH_TTL_MS` 60s → 10min** — transactions are immutable, so detail-page RPC enrichment no longer re-fetches on every cache miss.

## Result
`/txs` now returns at DB speed (ms). Homepage stats/tokens polls hit warm caches instead of remote RPC + full-table scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)