### PR TITLE
perf(api): build DB performance indexes from API startup (fixes slow /txs)

### DIFF
--- a/Makalu/api/src/index.ts
+++ b/Makalu/api/src/index.ts
@@ -17,6 +17,7 @@ import {
   resolveRequestId,
 } from './lib/logger.js';
 import { metricsMiddleware } from './lib/http-metrics.js';
+import { ensurePerformanceIndexes } from './lib/ensure-indexes.js';
 
 // Collect default metrics (CPU, memory, etc.)
 collectDefaultMetrics({ prefix: 'litho_api_' });
@@ -244,5 +245,10 @@ async function start() {
 
   const port = process.env.API_PORT || 4000;
   app.listen(port, () => logger.info({ port, build: BUILD_INFO }, 'api_listening'));
+
+  // Fire-and-forget: ensure DB performance indexes exist. Non-blocking so the
+  // server starts serving immediately while any (one-time) index build runs in
+  // the background. Idempotent — a fast no-op once the indexes are present.
+  void ensurePerformanceIndexes();
 }
 start();

--- a/Makalu/api/src/lib/ensure-indexes.ts
+++ b/Makalu/api/src/lib/ensure-indexes.ts
@@ -1,0 +1,76 @@
+import { Pool } from 'pg';
+import { logger } from './logger.js';
+
+// Performance indexes — source of truth: infra/postgres/performance-indexes.sql.
+// New databases get these from init.sql, but Postgres only runs init scripts on an
+// empty data dir, so existing prod volumes (millions of rows) are missing them —
+// leaving /txs to do a full table sort on every request (~9s on ~4.9M rows). The
+// first two entries fix the /txs sort + JOIN; the rest speed up address/token pages.
+//
+// This runs from the API (not only the indexer) because the live deploy pipeline
+// (deploy-simple.yaml → vps1) recreates the web/api containers but NOT the indexer
+// container, so an indexer-only migration never executes on the public host.
+const PERFORMANCE_INDEXES: string[] = [
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_time_height ON transactions(timestamp DESC, block_height DESC)',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_cosmos_hash ON evm_transactions(cosmos_tx_hash)',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_block_index ON transactions(block_height, tx_index)',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_sender_lower ON transactions(LOWER(sender))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_receiver_lower ON transactions(LOWER(receiver))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_hash_lower ON evm_transactions(LOWER(hash))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_cosmos_hash_lower ON evm_transactions(LOWER(cosmos_tx_hash))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_from_lower ON evm_transactions(LOWER(from_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_to_lower ON evm_transactions(LOWER(to_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_contract_lower ON evm_transactions(LOWER(contract_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_address_lower ON accounts(LOWER(address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_evm_lower ON accounts(LOWER(evm_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transfers_tx_lower ON token_transfers(LOWER(tx_hash))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transfers_contract_lower ON token_transfers(LOWER(contract_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transfers_from_lower ON token_transfers(LOWER(from_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transfers_to_lower ON token_transfers(LOWER(to_address))',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contracts_address_lower ON contracts(LOWER(address))',
+];
+
+/**
+ * Build the performance indexes if they are missing. Idempotent and crash-safe:
+ * CREATE INDEX CONCURRENTLY ... IF NOT EXISTS is a fast no-op once the index
+ * exists, so only the first run after a fresh DB pays the (one-time) build cost.
+ *
+ * Uses its OWN pool with no statement_timeout — the shared db.ts pool sets a 15s
+ * statement_timeout that would kill a multi-minute CONCURRENTLY build on a large
+ * table. CONCURRENTLY also cannot run inside a transaction block, so each index
+ * is issued as a standalone (autocommit) query.
+ */
+export async function ensurePerformanceIndexes(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    logger.warn('[migration] DATABASE_URL not set — skipping performance index migration');
+    return;
+  }
+
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    max: 2,
+    // Deliberately NO statement_timeout / query_timeout — index builds can take
+    // minutes on large tables and must not be interrupted.
+    statement_timeout: 0,
+    ssl: process.env.DATABASE_URL?.includes('sslmode=disable')
+      ? false
+      : { rejectUnauthorized: false },
+  });
+  pool.on('error', (err) => logger.error({ err: err.message }, '[migration] index pool error'));
+
+  try {
+    for (const sql of PERFORMANCE_INDEXES) {
+      try {
+        await pool.query(sql);
+        logger.info({ sql }, '[migration] performance index ensured');
+      } catch (err) {
+        // A failed CONCURRENTLY build can leave an INVALID index that IF NOT EXISTS
+        // will skip — log clearly so it can be dropped/rebuilt manually if needed.
+        logger.warn({ sql, err: err instanceof Error ? err.message : String(err) }, '[migration] performance index failed');
+      }
+    }
+    logger.info('[migration] performance index migration complete');
+  } finally {
+    await pool.end().catch(() => {});
+  }
+}


### PR DESCRIPTION
## Why a second PR
PR #21 added the index migration to the **indexer** startup, but it never ran on the live host. The `deploy-simple.yaml` → vps1 pipeline recreates only the **web/api** containers (and the image-wait only checks the explorer + api images) — the indexer container keeps its old image, so an indexer-only migration is skipped. `/txs` stayed at ~9s after that deploy.

## Fix
Run the same idempotent performance-index migration from the **API** startup (`Makalu/api/src/lib/ensure-indexes.ts`), since the api container IS recreated on every deploy.

- Dedicated `pg` pool with **`statement_timeout: 0`** — the shared `db.ts` pool's 15s timeout would kill a multi-minute `CREATE INDEX CONCURRENTLY` build on the ~4.9M-row `transactions` table
- `CREATE INDEX CONCURRENTLY IF NOT EXISTS` — no table lock, fast no-op once built
- non-blocking (`void ensurePerformanceIndexes()`) so the server serves immediately while the one-time build runs in background
- per-index try/catch; never crashes the API

The indexer-side copy (PR #21) is kept for environments where the indexer IS redeployed (EC2 / fresh setups). Both are idempotent and non-conflicting.

## Expected result
Once the API boots and `idx_tx_time_height` finishes building, `/txs` drops from ~9s to **< 1s**.

Note: CI's "OpenAPI Sync Check" is a **pre-existing** failure (undocumented `/nfts`, `/nfts/transfers` routes from the June 14 NFT feature) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)