### PR TITLE
docs(openapi): document /nfts and /nfts/transfers routes

### DIFF
--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -33,6 +33,7 @@ tags:
   - name: Transactions
   - name: Addresses
   - name: Tokens
+  - name: NFTs
   - name: Validators
   - name: Stats
   - name: Faucet
@@ -275,6 +276,31 @@ paths:
       responses:
         '200':
           description: Holder leaderboard (paged).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/JsonObject' }
+
+  # ───── NFTs (LEP100-6 collections) ───────────────────────────────────────
+  /nfts:
+    get:
+      tags: [NFTs]
+      summary: List indexed NFT (LEP100-6) collections with item / holder / transfer counts.
+      responses:
+        '200':
+          description: NFT collection array.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/JsonObject' }
+  /nfts/transfers:
+    get:
+      tags: [NFTs]
+      summary: Recent NFT transfers across all collections.
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated NFT transfer list.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/JsonObject' }


### PR DESCRIPTION
## Fix
The `/nfts` and `/nfts/transfers` (LEP100-6) routes were added with the NFT feature but never documented in `docs/api-reference/openapi.yaml`, so the **OpenAPI Sync Check** CI job has been failing on `main` since that feature landed.

Adds the two missing `GET` path entries (and an `NFTs` tag) mirroring the existing `/tokens` style. `verify-openapi-in-sync` now reports the route set in sync (26 endpoints).

Docs-only — no deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)