### PR TITLE
perf(db): add missing blocks indexes (block_time, proposer) for fast /stats/summary

### DIFF
--- a/Makalu/api/src/lib/ensure-indexes.ts
+++ b/Makalu/api/src/lib/ensure-indexes.ts
@@ -13,6 +13,10 @@ import { logger } from './logger.js';
 const PERFORMANCE_INDEXES: string[] = [
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_time_height ON transactions(timestamp DESC, block_height DESC)',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_cosmos_hash ON evm_transactions(cosmos_tx_hash)',
+  // blocks: idx_blocks_time fixes MAX(block_time) on /stats/summary (full scan
+  // of ~6.6M blocks otherwise); idx_blocks_proposer powers the validator detail page.
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_time ON blocks(block_time DESC)',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_proposer ON blocks(proposer_address)',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_block_index ON transactions(block_height, tx_index)',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_sender_lower ON transactions(LOWER(sender))',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_receiver_lower ON transactions(LOWER(receiver))',

--- a/Makalu/indexer/src/mappings.ts
+++ b/Makalu/indexer/src/mappings.ts
@@ -1329,6 +1329,8 @@ function startHealthServer(): void {
 const PERFORMANCE_INDEXES: string[] = [
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_time_height ON transactions(timestamp DESC, block_height DESC)',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_evm_tx_cosmos_hash ON evm_transactions(cosmos_tx_hash)',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_time ON blocks(block_time DESC)',
+  'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_proposer ON blocks(proposer_address)',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_block_index ON transactions(block_height, tx_index)',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_sender_lower ON transactions(LOWER(sender))',
   'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_receiver_lower ON transactions(LOWER(receiver))',

--- a/Makalu/infra/postgres/performance-indexes.sql
+++ b/Makalu/infra/postgres/performance-indexes.sql
@@ -1,6 +1,9 @@
 -- Apply this on existing explorer databases to speed up high-volume transaction queries.
 -- Safe to run multiple times.
 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_time ON blocks(block_time DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_blocks_proposer ON blocks(proposer_address);
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_block_index ON transactions(block_height, tx_index);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_time_height ON transactions(timestamp DESC, block_height DESC);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_sender_lower ON transactions(LOWER(sender));


### PR DESCRIPTION
## Problem
After the count-cache fixes (#24, #26), `/stats/summary` cold was still ~6-8s on a single API instance (confirmed single instance via monotonic `uptimeSec`). The remaining cost: `getSyncSummary()` runs `SELECT MAX(height), MAX(block_time) FROM blocks` on every stats miss, and **`idx_blocks_time` was never created on the prod volume** (init.sql only runs on an empty data dir — same root cause as the tx indexes). Without it, `MAX(block_time)` full-scans ~6.6M blocks.

My earlier `ensure-indexes` migration covered `transactions`/`evm_transactions` but not `blocks`.

## Fix
Add `idx_blocks_time` (fixes the stats MAX scan) and `idx_blocks_proposer` (validator detail page) to the ensure-indexes migration (API + indexer copies) and `performance-indexes.sql`. `blocks.hash` is already `UNIQUE`, so no extra index needed.

Expect cold `/stats/summary` to drop to ~1s once `idx_blocks_time` builds on first API boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)