### PR TITLE
docs(wallet): record Thanos as EIP-6963 (fi.thanos.wallet)

### DIFF
--- a/Makalu/explorer/context/WalletContext.tsx
+++ b/Makalu/explorer/context/WalletContext.tsx
@@ -41,13 +41,14 @@ if (typeof window !== 'undefined') {
       // WalletConnect Explorer IDs, in display order. Trust Wallet IS already
       // featured here (any injected/WalletConnect wallet still works regardless).
       //
-      // Thanos wallet: as of 2026-06-22 it is NOT in the WalletConnect registry
-      // (explorer-api search for "thanos" returns 0 listings), so there is no ID
-      // to feature yet. A Thanos *browser extension* that implements EIP-6963
-      // already appears automatically via enableEIP6963/enableInjected above — no
-      // change needed for that path. Once the wallet team confirms Thanos's
-      // WalletConnect registry ID, prepend it here (above MetaMask) to make it
-      // the primary featured wallet.
+      // Thanos wallet (thanos.fi): it is an EIP-6963 injected wallet with RDNS
+      // `fi.thanos.wallet` — NOT a WalletConnect-registry wallet (hence no entry
+      // in featuredWalletIds, and the empty registry search). It is discovered
+      // automatically via enableEIP6963/enableInjected above, so it already
+      // appears in this modal and works for connect + signing on Makalu (700777).
+      // For first-class "Sign in with Thanos" placement (SIWE auth + session),
+      // use the `thanos-connect` SDK (ThanosConnectButton / useThanos, chainId
+      // 700777) per https://thanos.fi/docs — deferred (adds a dep + auth flow).
       featuredWalletIds: [
         'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96', // MetaMask
         '4622a2b2d6af1c9844944291e5e7351a6aa24cd7b23099efac1b2fd875da31a0', // Trust Wallet


### PR DESCRIPTION
Corrects the earlier WalletContext note. Per https://thanos.fi/docs, Thanos is an **EIP-6963 injected wallet** (RDNS `fi.thanos.wallet`), not a WalletConnect-registry wallet — which is why the registry search was empty. It is auto-discovered via the existing `enableEIP6963`/`enableInjected` config, so it already appears in the connect modal and works for connect + signing on Makalu (700777).

First-class "Sign in with Thanos" (EIP-6963 discovery + SIWE + session) would use the npm `thanos-connect` SDK (`ThanosConnectButton` / `useThanos`) — deferred, as it adds a dependency + auth flow the read-only explorer doesn't currently need.

Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)