### PR TITLE
fix(indexer): reclassify NFT contracts regardless of prior 'token' tag

### DIFF
--- a/Makalu/indexer/src/mappings.ts
+++ b/Makalu/indexer/src/mappings.ts
@@ -1158,8 +1158,7 @@ async function backfillNftContractTypes(): Promise<void> {
        WHERE token_id IS NOT NULL
        ON CONFLICT (address) DO UPDATE SET
          contract_type = 'nft',
-         updated_at = NOW()
-       WHERE contracts.contract_type IS DISTINCT FROM 'token'`
+         updated_at = NOW()`
     );
     if ((result.rowCount ?? 0) > 0) {
       logger.info({ classified: result.rowCount }, '[backfill] NFT contracts classified');


### PR DESCRIPTION
## Problem

`backfillNftContractTypes()` had a guard that refused to update any contract already tagged `contract_type = 'token'`. The old indexer defaulted every contract to `'token'`, so on vps1 the backfill silently skipped every NFT contract on startup — resulting in the `/nfts` page showing nothing.

## Fix

Remove the `WHERE contracts.contract_type IS DISTINCT FROM 'token'` clause from the `ON CONFLICT DO UPDATE`. The subquery already filters to `WHERE token_id IS NOT NULL`, so pure ERC20s are structurally excluded — the guard was redundant and harmful.

## Effect on deploy

On next indexer restart after merge, `backfillNftContractTypes()` will reclassify all contracts that have ERC721 transfers in `token_transfers`, fixing the NFT collections page on makalu.litho.ai.

## Test plan
- [ ] Merge triggers deploy-simple.yaml (indexer image rebuild + recreation on vps1)
- [ ] After deploy: `GET /api/nfts` returns non-empty collections list
- [ ] `/nfts` page on makalu.litho.ai shows NFT collections