### PR TITLE
fix(api): prevent infinite proxy loop for unmatched /api/* routes

### DIFF
--- a/Makalu/api/src/index.ts
+++ b/Makalu/api/src/index.ts
@@ -214,8 +214,14 @@ async function start() {
 
   // The public edge currently reaches the API for non-API routes.
   // Proxy those GET/HEAD requests to the explorer so makalu.litho.ai still serves the site.
+  // Guard: never proxy /api/* or /graphql back to the explorer — those are our own routes,
+  // and proxying them causes an infinite loop (explorer rewrites /api/* back to this API).
   app.use(async (req: Request, res: Response, next: NextFunction) => {
     if (req.method !== 'GET' && req.method !== 'HEAD') {
+      next();
+      return;
+    }
+    if (req.path.startsWith('/api') || req.path === '/graphql') {
       next();
       return;
     }


### PR DESCRIPTION
## Problem

`/api/nfts` on makalu.litho.ai returns **431 Request Header Fields Too Large** after ~6s, so the `/nfts` page can't load data — even though PR #33 (the NFT backfill fix) is deployed (`/api/version` reports the correct SHA).

## Root cause

The API's catch-all middleware proxies every unmatched `GET`/`HEAD` request to the Next.js explorer (`EXPLORER_INTERNAL_URL`). But the explorer's `next.config.js` rewrites `/api/*` straight back to the API. So any `/api/*` path that **doesn't match an Express route** bounces API → Next.js → API → … in an infinite loop, accumulating `x-forwarded-for` headers on each hop until Node.js aborts the request with `431`.

On the live host the `/nfts` route is not matching (stale `dist` in the deployed image — a Docker GHA build-cache desync where the build-arg SHA updates but the cached build layer is stale), which is what drops it into the loop. This change fixes the loop for **any** unmatched `/api/*` route and, by touching the API source, forces a fresh image build so the route registers correctly again.

## Fix

Guard the explorer proxy so `/api/*` and `/graphql` never get proxied — they fall through to Express's default 404 instead.

## Verification

Ran the freshly-built `dist/` locally (no DB):

| Route | Before (live) | After (local fresh build) |
|---|---|---|
| `/api/nfts` | 431 @ ~6s | **200** `[]` @ 11ms |
| `/api/nfts/transfers` | 431 @ ~6s | **200** proper JSON @ 20ms |
| `/api/tokens` | 200 | 200 |
| `/api/does-not-exist` | 431 @ ~6s (loop) | **404** clean @ 3ms |

Confirms the NFT routes register correctly in a clean build, and unmatched `/api/*` now returns an honest 404 instead of looping into 431.