### PR TITLE
fix(api): serve /api/version from Express so the deploy health gate passes

### DIFF
--- a/Makalu/api/src/index.ts
+++ b/Makalu/api/src/index.ts
@@ -182,6 +182,16 @@ app.get('/version', (_req, res) => {
   res.status(200).json(buildVersionResponse('lithosphere-api', PROCESS_START, BUILD_INFO));
 });
 
+// Same payload under /api/version. The public health gate (deploy-simple.yaml)
+// polls https://makalu.litho.ai/api/version for the deployed SHA. Express owns
+// the whole /api/* surface, so serve it directly here instead of relying on the
+// explorer-proxy fallback — the /api/* proxy guard in start() intentionally
+// blocks that fallback to break the Express↔Next.js rewrite loop, which would
+// otherwise make /api/version (and every unmatched /api/* path) 431 / "unknown".
+app.get('/api/version', (_req, res) => {
+  res.status(200).json(buildVersionResponse('lithosphere-api', PROCESS_START, BUILD_INFO));
+});
+
 // Readiness probe (checks dependencies)
 app.get('/ready', async (_req, res) => {
   try {


### PR DESCRIPTION
## Why

PR #34 added an `/api/*` guard to stop the explorer-proxy infinite loop. But it had an unintended side effect: **the deploy rolled back.**

`deploy-simple.yaml`'s public health gate polls `https://makalu.litho.ai/api/version` for the deployed SHA. That endpoint was being served by the Next.js explorer (`pages/api/version.ts`) **through the Express explorer-proxy** — exactly the path PR #34's guard blocks. So after #34, `/api/version` returned Express's 404, the gate saw `gitSha=unknown` for all 18 polls, failed, and `ci-rollback.sh` reverted to the previous image.

Gate log from the failed run (28122167397):
```
[18/18] /api/version gitSha=unknown  /nfts=200  /api/stats/summary=200
::error::public health gate failed — makalu.litho.ai not serving 258e054...
```

## Fix

Express owns the entire `/api/*` surface, so serve `/api/version` directly with the API's own build info (same payload as `/version`). No proxy dependency. The `/api/*` proxy guard still breaks the Express↔Next.js loop for genuinely-unmatched routes.

The API's `gitSha` (from the `GIT_SHA` build-arg) equals the deployed commit, which is what the gate compares against — so the gate now passes and the deploy sticks.

## Verification (local, prod Dockerfile semantics)

```
/version       -> gitSha: <sha>            [200]
/api/version   -> gitSha: <sha>            [200]   <- gate reads this
/api/nfts      -> []                       [200]   <- route works
/api/zzz       -> (Express 404, instant)   [404]   <- loop guard, no 431
```

Follow-up noted separately: `Makalu/api` has **no committed `pnpm-lock.yaml`** (`COPY pnpm-lock.yaml*` matches nothing → CI resolves deps unpinned every build). Worth fixing for reproducibility.