### PR TITLE
fix(api): exclude NFT contracts from /tokens list

### DIFF
--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -2120,7 +2120,7 @@ export function explorerRouter(): Router {
       }>(
         `SELECT address, name, symbol, decimals, total_supply, contract_type, creator, created_at
          FROM contracts
-         WHERE contract_type IN ('token', 'nft') OR symbol IS NOT NULL
+         WHERE contract_type = 'token' OR (symbol IS NOT NULL AND contract_type IS DISTINCT FROM 'nft')
          ORDER BY created_at DESC
          LIMIT 100`
       ).catch(() => []);


### PR DESCRIPTION
## Why

After retiring the vps1 `patch-live-tokens.mjs` hotfix (which had hidden NFT contracts from `/tokens`), an NFT collection started appearing in `/api/tokens` as an `"Unknown"` row with `null` holders/transfers — because the real `/tokens` query includes `contract_type IN ('token','nft')`.

NFT collections have their own `/nfts` page, so they shouldn't pollute the fungible-token list.

## Fix

One-line query change: `WHERE contract_type = 'token' OR (symbol IS NOT NULL AND contract_type IS DISTINCT FROM 'nft')` — fungible tokens only. Matches the `/tokens` vs `/nfts` endpoint split.

## Context

This completes the cleanup of the long-standing vps1 token hotfix. The hotfix was deleting the `/nfts` routes on every container boot (root cause of NFTs being broken on makalu.litho.ai). It's now retired; the real API route serves both `/tokens` and `/nfts` correctly. Verified live: `/api/tokens` shows LITHO (holders climbing via the native-balance sweep) + all LEP100 tokens, `/api/nfts` returns the live collection.