### PR TITLE
fix(api): stop /stats/summary 500ing on the slow distinct-wallet aggregate

### DIFF
--- a/Makalu/api/src/db.ts
+++ b/Makalu/api/src/db.ts
@@ -32,3 +32,41 @@ export async function query<T = Record<string, unknown>>(
   const result = await pool.query(sql, params);
   return result.rows as T[];
 }
+
+// Dedicated pool for heavy analytics aggregates (homepage counts over multi-million
+// row tables) whose runtime grows with the chain and has crept past the main pool's
+// 15s statement_timeout. Without this, a cache-miss recompute throws "Query read
+// timeout" and 500s the whole /stats/summary endpoint (which the deploy health gate
+// checks). These queries are always cached, so the higher timeout only bites on the
+// occasional recompute. Kept separate so it can never starve the main request pool.
+let _slowPool: Pool | null = null;
+const SLOW_QUERY_TIMEOUT_MS = 60_000;
+
+function getSlowPool(): Pool {
+  if (!_slowPool) {
+    _slowPool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 4,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 3000,
+      query_timeout: SLOW_QUERY_TIMEOUT_MS,
+      statement_timeout: SLOW_QUERY_TIMEOUT_MS,
+      ssl: process.env.DATABASE_URL?.includes('sslmode=disable')
+        ? false
+        : { rejectUnauthorized: false },
+    });
+    _slowPool.on('error', (err) => {
+      logger.error({ err: err.message }, 'PostgreSQL slow-pool error');
+    });
+  }
+  return _slowPool;
+}
+
+export async function slowQuery<T = Record<string, unknown>>(
+  sql: string,
+  params: unknown[] = []
+): Promise<T[]> {
+  const pool = getSlowPool();
+  const result = await pool.query(sql, params);
+  return result.rows as T[];
+}

--- a/Makalu/api/src/index.ts
+++ b/Makalu/api/src/index.ts
@@ -8,7 +8,7 @@ import cors from 'cors';
 import { ApolloServer } from 'apollo-server-express';
 import { typeDefs, resolvers } from './schema.js';
 import { lithoRouter } from './litho.js';
-import { explorerRouter } from './routes.js';
+import { explorerRouter, prewarmStatsSummary } from './routes.js';
 import { register, collectDefaultMetrics, Gauge } from 'prom-client';
 import { readBuildInfo, buildVersionResponse } from './lib/build-info.js';
 import {
@@ -266,5 +266,10 @@ async function start() {
   // server starts serving immediately while any (one-time) index build runs in
   // the background. Idempotent — a fast no-op once the indexes are present.
   void ensurePerformanceIndexes();
+
+  // Fire-and-forget: warm the stats:summary cache (heavy distinct-wallet aggregate)
+  // so the deploy health gate and first users hit a warm cache rather than a
+  // multi-second recompute right after a restart.
+  void prewarmStatsSummary();
 }
 start();

--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -6,7 +6,7 @@
  */
 import { Router, type Request, type Response } from 'express';
 import { bech32 } from 'bech32';
-import { query } from './db.js';
+import { query, slowQuery } from './db.js';
 import { logger } from './lib/logger.js';
 import { audit } from './lib/audit.js';
 import { loadCachedShared } from './lib/shared-cache.js';
@@ -66,6 +66,11 @@ const INCONSISTENT_BLOCKS_TTL_MS = 300_000;
 // addresses over ~5M rows). Slow-drifting, so cache them well beyond the 15s
 // stats TTL — otherwise each stats miss re-runs the full-table scans.
 const STATS_COUNT_TTL_MS = 300_000;
+// Distinct-wallet count is the heaviest stats aggregate (UNION + DISTINCT over the
+// ~5M-row evm_transactions table, ~17s and growing). It's an all-time, slowly-
+// drifting figure, so cache it for an hour and compute it on the slow pool so a
+// recompute can't 500 /stats/summary.
+const STATS_WALLET_TTL_MS = 3_600_000;
 const EVM_ENRICH_TTL_MS = 600_000;
 const MAX_RUNTIME_CACHE_ENTRIES = 2_000;
 
@@ -728,18 +733,23 @@ async function getStatsSummaryResponse(): Promise<StatsSummaryResponse> {
     const [syncSummary, totalTransactions, walletAddresses, currentHolders, avgBlockTime, gasPriceWei] = await Promise.all([
       getSyncSummary(),
       // Slow-drifting totals on a ~5M-row table — long TTL, shared across replicas.
+      // slowQuery: COUNT(*) over the whole table can exceed the 15s pool timeout.
       loadCachedShared('count:transactions-total', STATS_COUNT_TTL_MS, async () => {
-        const rows = await query<CountRow>('SELECT COUNT(*) AS count FROM transactions');
+        const rows = await slowQuery<CountRow>('SELECT COUNT(*) AS count FROM transactions');
         return parseInt(rows[0]?.count ?? '0', 10);
       }),
-      loadCachedShared('count:wallet-addresses', STATS_COUNT_TTL_MS, async () => {
-        const rows = await query<CountRow>(
+      // Distinct wallets across cosmos accounts + EVM tx participants. The outer
+      // UNION already dedupes, so the inner DISTINCTs are redundant. Runs ~17s on
+      // the slow pool (would 500 the endpoint on the 15s main pool) and is cached
+      // for an hour since it's an all-time figure.
+      loadCachedShared('count:wallet-addresses', STATS_WALLET_TTL_MS, async () => {
+        const rows = await slowQuery<CountRow>(
           `SELECT COUNT(*) AS count FROM (
              SELECT address FROM accounts
              UNION
-             SELECT DISTINCT from_address FROM evm_transactions WHERE from_address IS NOT NULL
+             SELECT from_address FROM evm_transactions WHERE from_address IS NOT NULL
              UNION
-             SELECT DISTINCT to_address FROM evm_transactions WHERE to_address IS NOT NULL
+             SELECT to_address FROM evm_transactions WHERE to_address IS NOT NULL
            ) all_addrs`
         );
         return parseInt(rows[0]?.count ?? '0', 10);
@@ -771,6 +781,21 @@ async function getStatsSummaryResponse(): Promise<StatsSummaryResponse> {
       gasPriceWei,
     };
   });
+}
+
+/**
+ * Fire-and-forget warm of the stats:summary cache (and its heavy sub-counts) so the
+ * first request — and the deploy health-gate poll — after a restart hits a warm
+ * cache instead of paying the multi-second aggregate recompute. Best-effort: any
+ * error is swallowed so it never affects startup.
+ */
+export async function prewarmStatsSummary(): Promise<void> {
+  try {
+    await getStatsSummaryResponse();
+    logger.info('[stats] summary cache prewarmed');
+  } catch (err) {
+    logger.warn({ err: err instanceof Error ? err.message : String(err) }, '[stats] prewarm failed');
+  }
 }
 
 async function evmRpcCall(method: string, params: unknown[]): Promise<unknown> {


### PR DESCRIPTION
## Problem

`/api/stats/summary` started returning **500** (and the deploy health gate, which polls it, started failing → rollbacks). Root cause: the distinct-wallet count — `UNION` + `DISTINCT` over the ~5M-row `evm_transactions` table — has grown to **~17.5s** and now exceeds the request pool's 15s `statement_timeout`. On a cache miss the loader threw `Query read timeout`, rejecting the `Promise.all` and 500ing the whole endpoint (no fallback).

This is a pre-existing scaling issue that crossed the 15s threshold; it surfaced during the NFT/holder deploys.

## Fix

- **`db.ts`**: dedicated slow-query pool (60s timeout, `max: 4`, separate from the request pool so it can't starve it) for heavy analytics aggregates.
- **`routes.ts`**: distinct-wallet + total-transactions counts run on `slowQuery`; dropped the redundant inner `DISTINCT`s (the outer `UNION` already dedupes); distinct-wallet cached for 1h (`STATS_WALLET_TTL_MS`) since it's an all-time figure.
- **`index.ts`**: prewarm the `stats:summary` cache at startup so the first request / health-gate poll after a restart hits a warm cache.

## Status

Prod `/api/stats/summary` was **already restored** by warming the Redis `count:wallet-addresses` key (24h) while this rolls out — verified 200 @ 0.44s cached. This PR makes it durable: the recompute now completes on the 60s pool instead of 500ing, and startup prewarm keeps restarts clean.

Verified: API builds clean (`tsc`).