### PR TITLE
fix(api): dedupe /tokens by lower(address) (casing duplicates)

### DIFF
--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -2145,9 +2145,18 @@ export function explorerRouter(): Router {
         creator: string | null;
         created_at: Date;
       }>(
+        // Dedupe by lower(address): the same contract can exist as two rows that
+        // differ only by EVM-address casing — a checksummed seeded row and a
+        // lowercased indexer-detected row. Collapse them with DISTINCT ON, keeping
+        // the checksummed (seeded) row, which carries the canonical name/symbol.
         `SELECT address, name, symbol, decimals, total_supply, contract_type, creator, created_at
-         FROM contracts
-         WHERE contract_type = 'token' OR (symbol IS NOT NULL AND contract_type IS DISTINCT FROM 'nft')
+         FROM (
+           SELECT DISTINCT ON (lower(address))
+                  address, name, symbol, decimals, total_supply, contract_type, creator, created_at
+           FROM contracts
+           WHERE contract_type = 'token' OR (symbol IS NOT NULL AND contract_type IS DISTINCT FROM 'nft')
+           ORDER BY lower(address), (address = lower(address)), created_at ASC
+         ) deduped
          ORDER BY created_at DESC
          LIMIT 100`
       ).catch(() => []);


### PR DESCRIPTION
## Problem
`https://makalu.litho.ai/tokens` shows **every LEP-100 token twice** (21 rows = native LITHO + 10 tokens × 2).

## Root cause
The `contracts` table holds **two rows for the same contract that differ only by EVM-address casing**:
- a **checksummed** seeded row — e.g. `0x151ef362eA96…`, name `FurGPT`
- a **lowercased** indexer-detected row — `0x151ef362ea96…`, name `Finesse GPT`

The `address` column is case-sensitive, so `ON CONFLICT (address)` never merges them — both survive and `/api/tokens` returns both.

## Fix
Dedupe the `/tokens` query with `DISTINCT ON (lower(address))`, keeping the **checksummed seeded row** (canonical name/symbol), and preserve the existing `created_at DESC` display order via an outer query. API typechecks clean.

## Note (follow-up, not in this PR)
This resolves the visible duplicate on `/tokens`. The underlying duplicate **rows** still exist in the DB (the indexer inserts lowercased contract rows while the seed uses checksummed). A proper root fix would normalize addresses to one casing + a one-time dedupe migration (touches prod data) — happy to do that next if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)