### PR TITLE
fix(explorer): header balance, sign-in label, and block spacing

### DIFF
--- a/Makalu/explorer/components/Header.tsx
+++ b/Makalu/explorer/components/Header.tsx
@@ -11,6 +11,9 @@ import {
 import SearchBar from './SearchBar';
 import { EXPLORER_TITLE } from '@/lib/constants';
 import { formatValue } from '@/lib/format';
+import { apiFetch } from '@/lib/api';
+
+const THANOS_SESSION_KEY = 'thanos_session';
 
 type EthereumRequestProvider = {
   request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
@@ -61,6 +64,7 @@ function HeaderContent() {
   const [walletMenuOpen, setWalletMenuOpen] = useState(false);
   const [lithoBalance, setLithoBalance] = useState<string | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
+  const [thanosSignedIn, setThanosSignedIn] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
   const moreMenuRef = useRef<HTMLDivElement>(null);
   const walletMenuRef = useRef<HTMLDivElement>(null);
@@ -84,6 +88,38 @@ function HeaderContent() {
     window.addEventListener('open-wallet-menu', handleOpenWalletMenu);
     return () => window.removeEventListener('open-wallet-menu', handleOpenWalletMenu);
   }, []);
+
+  // Reflect the Thanos SIWE session (persisted by ThanosSignIn in localStorage)
+  // so the "Sign In" nav link updates to "Signed In" without a page reload.
+  useEffect(() => {
+    const readSession = () => {
+      try {
+        const raw = localStorage.getItem(THANOS_SESSION_KEY);
+        if (!raw) {
+          setThanosSignedIn(false);
+          return;
+        }
+        const session = JSON.parse(raw) as { expiresAt?: number | null };
+        setThanosSignedIn(!session.expiresAt || session.expiresAt * 1000 > Date.now());
+      } catch {
+        setThanosSignedIn(false);
+      }
+    };
+
+    readSession();
+    window.addEventListener('thanos-session-changed', readSession);
+    window.addEventListener('storage', readSession);
+    return () => {
+      window.removeEventListener('thanos-session-changed', readSession);
+      window.removeEventListener('storage', readSession);
+    };
+  }, []);
+
+  const navItems = NAV_ITEMS.map((item) =>
+    item.href === '/signin'
+      ? { ...item, label: thanosSignedIn ? 'Signed In' : 'Sign In' }
+      : item,
+  );
 
   // Close "More" dropdown when clicking outside
   useEffect(() => {
@@ -282,8 +318,11 @@ function HeaderContent() {
         setBalanceLoading(true);
       }
 
+      const toWei = (value: string): bigint =>
+        BigInt(value.startsWith('0x') ? value : `0x${value}`);
+
       try {
-        let hexBalance: string | null = null;
+        let wei: bigint | null = null;
 
         const injectedProvider =
           typeof window !== 'undefined'
@@ -293,53 +332,65 @@ function HeaderContent() {
         const provider =
           (walletProvider as EthereumRequestProvider | undefined) ?? injectedProvider;
 
+        // 1) Live value straight from the connected wallet when it's on Makalu.
         if (provider?.request && chainId === MAKALU_CHAIN_ID) {
-          const result = await provider.request({
-            method: 'eth_getBalance',
-            params: [address, 'latest'],
-          });
-          if (typeof result === 'string') {
-            hexBalance = result;
-          }
-        }
-
-        // Fallback to public RPC to keep balance visible even when wallet is on another chain.
-        if (!hexBalance) {
-          const response = await fetch('https://rpc.litho.ai', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              jsonrpc: '2.0',
+          try {
+            const result = await provider.request({
               method: 'eth_getBalance',
               params: [address, 'latest'],
-              id: 1,
-            }),
-          });
-
-          if (response.ok) {
-            const data: { result?: unknown } = await response.json();
-            if (typeof data.result === 'string') {
-              hexBalance = data.result;
-            }
+            });
+            if (typeof result === 'string') wei = toWei(result);
+          } catch {
+            /* fall through to the API/RPC fallbacks */
           }
         }
 
-        if (!hexBalance) {
-          throw new Error('Balance unavailable');
+        // 2) Same-origin API (nginx proxies /api → Express, which resolves the
+        //    native balance server-side). This avoids the CORS failures that a
+        //    direct browser POST to rpc.litho.ai hits from the makalu.litho.ai
+        //    origin — the reason the balance showed "Unavailable".
+        if (wei === null) {
+          try {
+            const data = await apiFetch<{ balance?: string; balanceSource?: string }>(
+              `/address/${address}`,
+            );
+            if (data.balanceSource !== 'unavailable' && typeof data.balance === 'string') {
+              wei = BigInt(data.balance);
+            }
+          } catch {
+            /* fall through to the public RPC fallback */
+          }
         }
 
-        const normalizedHex = hexBalance.startsWith('0x') ? hexBalance : `0x${hexBalance}`;
-        const wei = BigInt(normalizedHex);
-        const formattedBalance = formatValue(wei.toString());
-
-        if (!cancelled) {
-          setLithoBalance(formattedBalance);
+        // 3) Last resort: direct public RPC (works only where CORS is permitted).
+        if (wei === null) {
+          try {
+            const response = await fetch('https://rpc.litho.ai', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'eth_getBalance',
+                params: [address, 'latest'],
+                id: 1,
+              }),
+            });
+            if (response.ok) {
+              const data: { result?: unknown } = await response.json();
+              if (typeof data.result === 'string') wei = toWei(data.result);
+            }
+          } catch {
+            /* keep the last-known balance below */
+          }
         }
+
+        if (!cancelled && wei !== null) {
+          setLithoBalance(formatValue(wei.toString()));
+        }
+        // On a transient miss we intentionally keep the last-known balance rather
+        // than flashing "Unavailable" until the next poll succeeds.
       } catch (error) {
         console.error('Failed to fetch LITHO balance:', error);
-        if (!cancelled) {
-          setLithoBalance(null);
-        }
       } finally {
         if (showLoader && !cancelled) {
           setBalanceLoading(false);
@@ -574,7 +625,7 @@ function HeaderContent() {
         </div>
 
         <nav className="space-y-1">
-          {NAV_ITEMS.map((item) => (
+          {navItems.map((item) => (
             <Link
               key={item.href}
               href={item.href}
@@ -685,7 +736,7 @@ function HeaderContent() {
 
           {/* Desktop nav */}
           <nav className="hidden lg:flex items-center gap-1">
-            {NAV_ITEMS.map((item) => (
+            {navItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}

--- a/Makalu/explorer/components/ThanosSignIn.tsx
+++ b/Makalu/explorer/components/ThanosSignIn.tsx
@@ -23,6 +23,13 @@ function shorten(addr: string): string {
   return addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
 }
 
+/** Notify the Header (same tab) that the sign-in state changed. */
+function notifySessionChanged() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('thanos-session-changed'));
+  }
+}
+
 export default function ThanosSignIn() {
   const [session, setSession] = useState<StoredSession | null>(null);
   const [error, setError] = useState('');
@@ -57,6 +64,7 @@ export default function ThanosSignIn() {
     } catch {
       /* storage may be unavailable (private mode) — session stays in memory */
     }
+    notifySessionChanged();
   }
 
   function signOut() {
@@ -67,6 +75,7 @@ export default function ThanosSignIn() {
     } catch {
       /* ignore */
     }
+    notifySessionChanged();
   }
 
   if (session) {

--- a/Makalu/explorer/pages/index.tsx
+++ b/Makalu/explorer/pages/index.tsx
@@ -291,7 +291,7 @@ function HomeContent({ initialStats, initialValidators }: HomeProps) {
                         key={block.height}
                         className="grid gap-3 rounded-2xl border border-white/10 bg-black/25 p-4 xl:grid-cols-[minmax(0,18rem)_minmax(0,22.5rem)] xl:justify-between xl:gap-6 xl:items-center"
                       >
-                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)_minmax(4.75rem,0.45fr)] xl:max-w-[18rem]">
+                        <div className="grid grid-cols-2 gap-3 sm:gap-x-6 sm:grid-cols-[max-content_minmax(0,0.8fr)_minmax(4.75rem,0.45fr)] xl:max-w-[18rem]">
                           <div className="min-w-0">
                             <div className="text-xs text-white/45">Height</div>
                             <Link


### PR DESCRIPTION
Three explorer UI fixes (Makalu / Lithoscan):

## 1. Header balance showed "Unavailable" instead of coins
The header fetched the native balance via a direct browser `POST` to `https://rpc.litho.ai` — a cross-origin call from the `makalu.litho.ai` origin that the RPC's CORS policy blocks, so it always fell through to "Unavailable". The address page works because it uses the same-origin `/api/address/:address` proxy.

Fetch order is now: connected wallet provider → **same-origin `/api/address/:address`** (new, no CORS) → direct public RPC. On a transient miss the last-known balance is kept instead of flashing "Unavailable".

## 2. "Sign In" nav link stayed after signing in
The link was static. The header now reads the persisted `thanos_session` (validating expiry) and renders **"Signed In"** when authenticated. `ThanosSignIn` dispatches a `thanos-session-changed` event (and the header also listens for cross-tab `storage`) so the label updates without a reload.

## 3. Latest Blocks — Height number touched Age
Height column was `minmax(0,1fr)`, letting the long height number overflow against Age. Now sized to `max-content` with `sm:gap-x-6` for a clean gap; rest of the layout unchanged.

Explorer-side only. `tsc` clean for the changed files (pre-existing `test/build-info.test.ts` env-typing errors are unrelated).