### PR TITLE
fix(explorer): block stat overlap + reliable header balance/sign-in

### DIFF
--- a/Makalu/explorer/components/Header.tsx
+++ b/Makalu/explorer/components/Header.tsx
@@ -115,9 +115,11 @@ function HeaderContent() {
     };
   }, []);
 
+  // A connected wallet OR a persisted Thanos SIWE session both count as signed in,
+  // so the nav reflects either path instead of always showing "Sign In".
   const navItems = NAV_ITEMS.map((item) =>
     item.href === '/signin'
-      ? { ...item, label: thanosSignedIn ? 'Signed In' : 'Sign In' }
+      ? { ...item, label: thanosSignedIn || isConnected ? 'Signed In' : 'Sign In' }
       : item,
   );
 
@@ -332,31 +334,31 @@ function HeaderContent() {
         const provider =
           (walletProvider as EthereumRequestProvider | undefined) ?? injectedProvider;
 
-        // 1) Live value straight from the connected wallet when it's on Makalu.
-        if (provider?.request && chainId === MAKALU_CHAIN_ID) {
+        // 1) Same-origin API first — proven reliable for every address form
+        //    (bech32, lowercase and checksummed 0x). nginx proxies /api → Express,
+        //    which resolves the live native balance server-side, so this avoids the
+        //    CORS failures a direct browser POST to rpc.litho.ai hits from the
+        //    makalu.litho.ai origin (the original cause of "Unavailable"). Trying it
+        //    first also means a stalled wallet provider can't block the display.
+        try {
+          const data = await apiFetch<{ balance?: string; balanceSource?: string }>(
+            `/address/${address}`,
+          );
+          if (data.balanceSource !== 'unavailable' && typeof data.balance === 'string') {
+            wei = BigInt(data.balance);
+          }
+        } catch {
+          /* fall through to the wallet/RPC fallbacks */
+        }
+
+        // 2) Cross-check via the connected wallet only if the API gave nothing.
+        if (wei === null && provider?.request && chainId === MAKALU_CHAIN_ID) {
           try {
             const result = await provider.request({
               method: 'eth_getBalance',
               params: [address, 'latest'],
             });
             if (typeof result === 'string') wei = toWei(result);
-          } catch {
-            /* fall through to the API/RPC fallbacks */
-          }
-        }
-
-        // 2) Same-origin API (nginx proxies /api → Express, which resolves the
-        //    native balance server-side). This avoids the CORS failures that a
-        //    direct browser POST to rpc.litho.ai hits from the makalu.litho.ai
-        //    origin — the reason the balance showed "Unavailable".
-        if (wei === null) {
-          try {
-            const data = await apiFetch<{ balance?: string; balanceSource?: string }>(
-              `/address/${address}`,
-            );
-            if (data.balanceSource !== 'unavailable' && typeof data.balance === 'string') {
-              wei = BigInt(data.balance);
-            }
           } catch {
             /* fall through to the public RPC fallback */
           }

--- a/Makalu/explorer/pages/index.tsx
+++ b/Makalu/explorer/pages/index.tsx
@@ -289,10 +289,10 @@ function HomeContent({ initialStats, initialValidators }: HomeProps) {
                   : (Array.isArray(blocks) ? blocks : []).map((block) => (
                       <div
                         key={block.height}
-                        className="grid gap-3 rounded-2xl border border-white/10 bg-black/25 p-4 xl:grid-cols-[minmax(0,18rem)_minmax(0,22.5rem)] xl:justify-between xl:gap-6 xl:items-center"
+                        className="grid gap-3 rounded-2xl border border-white/10 bg-black/25 p-4 xl:grid-cols-[auto_minmax(0,22.5rem)] xl:justify-between xl:gap-6 xl:items-center"
                       >
-                        <div className="grid grid-cols-2 gap-3 sm:gap-x-6 sm:grid-cols-[max-content_minmax(0,0.8fr)_minmax(4.75rem,0.45fr)] xl:max-w-[18rem]">
-                          <div className="min-w-0">
+                        <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
+                          <div className="shrink-0">
                             <div className="text-xs text-white/45">Height</div>
                             <Link
                               href={`/blocks/${block.height}`}
@@ -301,11 +301,11 @@ function HomeContent({ initialStats, initialValidators }: HomeProps) {
                               #{formatNumber(block.height)}
                             </Link>
                           </div>
-                          <div className="min-w-0">
+                          <div className="shrink-0">
                             <div className="text-xs text-white/45">Age</div>
                             <div className="mt-1 whitespace-nowrap font-medium tabular-nums">{timeAgo(block.timestamp)}</div>
                           </div>
-                          <div className="min-w-0 sm:justify-self-start">
+                          <div className="shrink-0">
                             <div className="text-xs text-white/45">
                               <span className="sm:hidden">Txns</span>
                               <span className="hidden sm:inline">Transactions</span>


### PR DESCRIPTION
Follow-up to #43 based on the live result.

### 1. Latest Blocks — Age/Transactions overlap
The `max-content` grid from #43 fixed Height↔Age but let the `whitespace-nowrap` Age text overflow into the Transactions column. Replaced the fractional grid with a **content-sized flex row** (`shrink-0` stats, `gap-x-6`) and an `auto`-sized outer track, so each stat keeps its natural width with even spacing and nothing overlaps.

### 2. Header balance still "Unavailable"
Verified the same-origin API returns correct balances for **every** address form (bech32, lowercase `0x`, checksummed `0x`). The fragile part was trying the **wallet provider first** — now the API is the primary source and the wallet is a secondary cross-check, so a stalled provider can't leave the balance stuck.

### 3. "Sign In" showing with a wallet connected
The nav now treats a **connected wallet OR a Thanos SIWE session** as signed in, showing "Signed In" once a wallet is connected.

`tsc` clean for both files. Deploys to vps1 on merge (GHCR creds refreshed).