### PR TITLE
fix(api,explorer): live-RPC balance for unindexed wallets; hide Sign In when connected

### DIFF
--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -1905,6 +1905,27 @@ export function explorerRouter(): Router {
         return;
       }
 
+      // 5. Valid EVM address with no indexed presence (no account, contract, txs
+      //    or proposed blocks). A freshly-funded wallet has a real on-chain
+      //    balance but no indexed activity yet, so resolve it live via RPC and
+      //    return a synthetic zero-activity account instead of 404-ing. Only when
+      //    the RPC actually answers (balanceSource 'rpc'); otherwise keep the 404.
+      if (forms.evmAddress) {
+        const balanceState = await resolveNativeBalance(forms.evmAddress, null);
+        if (balanceState.balanceSource === 'rpc') {
+          res.json({
+            address: forms.queryLower.startsWith('0x') ? forms.evmAddress : (forms.cosmosAddress ?? forms.evmAddress),
+            evmAddress: forms.evmAddress,
+            cosmosAddress: forms.cosmosAddress,
+            balance: balanceState.balance,
+            balanceSource: balanceState.balanceSource,
+            txCount: 0,
+            lastSeen: new Date().toISOString(),
+          });
+          return;
+        }
+      }
+
       res.status(404).json({ message: 'Account not found' });
     } catch (err) {
       logger.error({ err: err instanceof Error ? err.message : String(err) }, '[api] /address/:address error');

--- a/Makalu/explorer/components/Header.tsx
+++ b/Makalu/explorer/components/Header.tsx
@@ -115,13 +115,13 @@ function HeaderContent() {
     };
   }, []);
 
-  // A connected wallet OR a persisted Thanos SIWE session both count as signed in,
-  // so the nav reflects either path instead of always showing "Sign In".
-  const navItems = NAV_ITEMS.map((item) =>
-    item.href === '/signin'
-      ? { ...item, label: thanosSignedIn || isConnected ? 'Signed In' : 'Sign In' }
-      : item,
-  );
+  // A connected wallet OR a persisted Thanos SIWE session both count as signed in.
+  // Once signed in, hide the "Sign In" nav link entirely (the wallet pill already
+  // shows the account) rather than leaving a redundant button in the nav.
+  const isSignedIn = thanosSignedIn || isConnected;
+  const navItems = isSignedIn
+    ? NAV_ITEMS.filter((item) => item.href !== '/signin')
+    : NAV_ITEMS;
 
   // Close "More" dropdown when clicking outside
   useEffect(() => {


### PR DESCRIPTION
Follow-up to #44 — pins down why the header balance stayed "Unavailable" and the Sign In ask.

### Balance "Unavailable" — real root cause
`GET /api/address/:address` returns **404** for any address with no indexed presence (no account/contract/txs/proposed blocks). A freshly-connected wallet (e.g. `0x0AE6…F285`) has a real on-chain balance but no indexed activity, so the header's API-first fetch 404'd, the wallet-provider fallback was skipped (WalletConnect has no injected `window.ethereum`), and the public-RPC fallback is CORS-blocked → "Unavailable".

**Fix:** add a step-5 live-RPC resolve before the 404 — for a valid EVM address, `resolveNativeBalance` does `eth_getBalance` and returns a synthetic zero-activity account when the RPC answers (`balanceSource: 'rpc'`). Still 404s when the RPC genuinely can't resolve, so the "unknown address" test still holds (verified: 7 address tests pass).

### Sign In
Hide the `/signin` nav link entirely when a wallet is connected (or a Thanos session exists), instead of showing a redundant "Signed In" button — the wallet pill already shows the account.

Touches `Makalu/api` + `Makalu/explorer`; both web and api are recreated on deploy. `tsc` clean for both; address tests green.