### PR TITLE
fix(bridge): correct BNB dest bridge address (+ coming-soon guard rails)

### DIFF
--- a/Makalu/explorer/lib/bridge.ts
+++ b/Makalu/explorer/lib/bridge.ts
@@ -46,6 +46,8 @@ export interface ChainInfo {
   bridge: string;
   /** Lithosphere chain (Makalu/Kamet) where the LEP-100 tokens natively live. */
   litho: boolean;
+  /** Listed but not yet routable — shown grayed out, cannot be selected. */
+  comingSoon?: boolean;
 }
 
 // All chains the MultX bridge is wired to (mirrors the live bridge-api /chains).
@@ -57,7 +59,9 @@ export const BRIDGE_CHAIN_LIST: ChainInfo[] = [
   { key: 'kamet', chainId: 900523, name: 'Lithosphere Kamet', short: 'Kamet', bridge: '0x3a896BDF3a1088287FA84aB5a43bB30e2535F263', litho: true },
   { key: 'sepolia', chainId: 11155111, name: 'Ethereum Sepolia', short: 'Sepolia', bridge: '0xfdA3b83FE8438123eAF5153945A46F8fcF6175f4', litho: false },
   { key: 'base', chainId: 84532, name: 'Base Sepolia', short: 'Base Sepolia', bridge: '0xfdA3b83FE8438123eAF5153945A46F8fcF6175f4', litho: false },
-  { key: 'bnb', chainId: 97, name: 'BNB Chain Testnet', short: 'BNB Testnet', bridge: '0x6714951EFC1ED9C703c946c48F7cD666948BBB06', litho: false },
+  // Deployed 2026-07-06 with wrapped tokens; Kamet→BNB proven end-to-end same
+  // day. (0x6714…BB06, seen in some older repo defaults, is a stale address.)
+  { key: 'bnb', chainId: 97, name: 'BNB Chain Testnet', short: 'BNB Testnet', bridge: '0x93d74580a7b63a5B1FE5Aae05b7470bf9317aF9A', litho: false },
 ];
 
 /** Chains a user can lock FROM — the Lithosphere chains where LEP-100s live. */

--- a/Makalu/explorer/pages/bridge.tsx
+++ b/Makalu/explorer/pages/bridge.tsx
@@ -70,9 +70,13 @@ function BridgeContent() {
     [symbol],
   );
 
-  // Keep the destination valid when the source changes (can't equal source).
+  // Keep the destination valid when the source changes (can't equal source,
+  // can't be a coming-soon chain).
   useEffect(() => {
-    if (toKey === fromKey) setToKey(destOptions[0]?.key ?? 'kamet');
+    const current = destOptions.find((c) => c.key === toKey);
+    if (toKey === fromKey || !current || current.comingSoon) {
+      setToKey(destOptions.find((c) => !c.comingSoon)?.key ?? 'kamet');
+    }
   }, [fromKey, toKey, destOptions]);
 
   const sourceTokenAddr = tokenAddressFor(token, source.key);
@@ -128,6 +132,10 @@ function BridgeContent() {
     }
     if (!/^\d+(\.\d+)?$/.test(amount) || Number(amount) <= 0) {
       show('Enter a valid amount.', 'error');
+      return;
+    }
+    if (dest.comingSoon) {
+      show(`${dest.name} is not routable yet — locked funds would strand. Pick another destination.`, 'error');
       return;
     }
     setBusy(true);
@@ -241,7 +249,9 @@ function BridgeContent() {
                 <label className="mb-2 block text-sm text-white/70">To</label>
                 <select value={dest.key} onChange={(e) => setToKey(e.target.value)} className={selectCls}>
                   {destOptions.map((c) => (
-                    <option key={c.key} value={c.key}>{c.name}</option>
+                    <option key={c.key} value={c.key} disabled={c.comingSoon} className={c.comingSoon ? 'text-white/30' : undefined}>
+                      {c.name}{c.comingSoon ? ' — coming soon' : ''}
+                    </option>
                   ))}
                 </select>
               </div>


### PR DESCRIPTION
**Premise of the original PR was wrong** — the infra team corrected us: BNB is live, we were pointing at a stale address.

- The explorer's BNB entry used `0x6714…BB06`, a stale default that lingers in a few repo files and is **not** a functioning `MultXBridgeDest` (view calls revert).
- The real BNB testnet dest bridge is **`0x93d74580a7b63a5B1FE5Aae05b7470bf9317aF9A`** (deployed 2026-07-06 with wrapped tokens; Kamet→BNB proven end-to-end same day). Verified independently: live `bridge-api /chains` returns it, and on-chain it's unpaused with the correct 5-of-7 validator set.
- BNB is therefore **fully selectable** — no gray-out.

This PR also keeps a generic `comingSoon` flag on `ChainInfo` with UI guard rails (disabled dropdown option, auto-select skip, `handleLock` refusal) so future not-yet-routable chains can be listed safely. **No chain currently sets it.**

Explorer typechecks clean (only the pre-existing `build-info.test.ts` issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)