### PR TITLE
fix(bridge): hard-verify wallet chain after switch before approve/lock

### DIFF
--- a/Makalu/explorer/context/WalletContext.tsx
+++ b/Makalu/explorer/context/WalletContext.tsx
@@ -11,6 +11,17 @@ const chains = [
     explorerUrl: 'https://makalu.litho.ai',
     rpcUrl: 'https://rpc.litho.ai',
   },
+  // Kamet is a first-class chain for the bridge flow (lock/claim happen there
+  // for Kamet-origin routes). Without it in this list, Web3Modal flags a
+  // Kamet-connected wallet as "unsupported network" and nags the user to
+  // switch back to Makalu on every connect/refresh.
+  {
+    chainId: 900523,
+    name: 'Lithosphere Kamet',
+    currency: 'LITHO',
+    explorerUrl: 'https://kamet.litho.ai',
+    rpcUrl: 'https://rpc-3.litho.ai',
+  },
 ];
 
 const metadata = {

--- a/Makalu/explorer/pages/bridge.tsx
+++ b/Makalu/explorer/pages/bridge.tsx
@@ -89,21 +89,38 @@ function BridgeContent() {
   const ensureChain = useCallback(
     async (targetId: number) => {
       if (!walletProvider) throw new Error('Wallet not connected');
-      if (Number(chainId) === targetId) return;
       const params = CHAIN_PARAMS[targetId];
       if (!params) throw new Error(`No wallet config for chain ${targetId}`);
       const provider = walletProvider as Eip1193Provider;
+
+      // The wallet's real chain, straight from the provider — the hook's
+      // chainId can lag, and a "successful" switch prompt does not guarantee
+      // the wallet actually landed on the target chain (seen live: MetaMask
+      // stayed on Makalu while the flow proceeded to approve a Kamet token).
+      const actualChain = async () =>
+        Number(await provider.request({ method: 'eth_chainId' }));
+
+      if ((await actualChain()) === targetId) return;
       try {
         await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: params.chainId }] });
       } catch (err: unknown) {
-        if ((err as { code?: number })?.code === 4902) {
-          await provider.request({ method: 'wallet_addEthereumChain', params: [params] });
-        } else {
-          throw err;
-        }
+        // MetaMask signals "unknown chain" as 4902, but sometimes wraps it in
+        // a -32603 internal error — attempt the add on any failure and let the
+        // verification below be the arbiter.
+        await provider.request({ method: 'wallet_addEthereumChain', params: [params] });
       }
+      // Hard gate: never proceed to approve/lock until the wallet is really
+      // on the target chain (some wallets apply the switch asynchronously).
+      for (let attempt = 0; attempt < 4; attempt++) {
+        if ((await actualChain()) === targetId) return;
+        await new Promise((r) => setTimeout(r, 700));
+      }
+      throw new Error(
+        `Wallet is still on chain ${await actualChain()}, not ${params.chainName} (${targetId}). ` +
+        `Switch manually in the wallet — network RPC must be ${params.rpcUrls[0]} — then retry.`,
+      );
     },
-    [walletProvider, chainId],
+    [walletProvider],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Caught during the live joint bridge run: MetaMask never actually switched to Kamet, but the flow proceeded — first an `allowance` read failing with `CALL_EXCEPTION` (wrong chain, no contract at the token address), then an approve reaching MetaMask **on Makalu** targeting the **Kamet** wLITHO contract (`eth_sendTransaction` → `-32603`). Fails safe (no contract at the address on the wrong chain), but the errors were raw hex dumps and the flow should never have gotten there.

`ensureChain` now:
- reads `eth_chainId` **directly from the provider** (the Web3Modal hook's `chainId` can lag),
- attempts `wallet_addEthereumChain` on **any** switch failure (MetaMask sometimes wraps the 4902 unknown-chain code inside a `-32603` internal error),
- polls up to ~3s for wallets that apply the switch asynchronously,
- and **hard-stops with an actionable message** (expected chain + required RPC) if the wallet never lands — approve/lock can no longer execute against the wrong chain.

Explorer typechecks clean (only the pre-existing `build-info.test.ts` issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)