### PR TITLE
fix(wallet): whitelist bridge dest chains to stop unsupported-network nag

### DIFF
--- a/Makalu/explorer/context/WalletContext.tsx
+++ b/Makalu/explorer/context/WalletContext.tsx
@@ -22,6 +22,33 @@ const chains = [
     explorerUrl: 'https://kamet.litho.ai',
     rpcUrl: 'https://rpc-3.litho.ai',
   },
+  // Bridge destination chains. The lock always runs on a Lithosphere source
+  // chain (Makalu/Kamet), so the wallet never has to sign here — but bridge
+  // users routinely switch their wallet to a destination chain to import and
+  // view the wrapped token after a transfer. Whitelisting these stops the
+  // "app doesn't support your current network" popover from firing whenever a
+  // wallet legitimately sits on Sepolia / Base / BNB.
+  {
+    chainId: 11155111,
+    name: 'Ethereum Sepolia',
+    currency: 'ETH',
+    explorerUrl: 'https://sepolia.etherscan.io',
+    rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com',
+  },
+  {
+    chainId: 84532,
+    name: 'Base Sepolia',
+    currency: 'ETH',
+    explorerUrl: 'https://sepolia.basescan.org',
+    rpcUrl: 'https://sepolia.base.org',
+  },
+  {
+    chainId: 97,
+    name: 'BNB Smart Chain Testnet',
+    currency: 'tBNB',
+    explorerUrl: 'https://testnet.bscscan.com',
+    rpcUrl: 'https://bsc-testnet-rpc.publicnode.com',
+  },
 ];
 
 const metadata = {


### PR DESCRIPTION
## Problem
The Web3Modal "Switch Network — This app doesn't support your current network" popover keeps appearing for bridge users, offering only "Lithosphere Makalu Testnet". Confirmed **not** a stale-cache issue this time — the live bundle already contains the Kamet fix (PR #47). Root cause: the wallet is sitting on an **external destination chain** (Ethereum Sepolia after a bridge run, or BNB) to import/view the wrapped token, and only Makalu + Kamet were whitelisted in the Web3Modal `chains` list.

## Fix
Add the three bridge destination chains — Ethereum Sepolia (11155111), Base Sepolia (84532), BNB Smart Chain Testnet (97) — to the `chains` array in `WalletContext.tsx`.

The bridge flow is unchanged: the lock always runs on a Lithosphere source chain, and `ensureChain` in `bridge.tsx` still hard-switches the wallet to the source before approve/lock. This change only stops Web3Modal from flagging the destination chains as "unsupported" when a bridge user legitimately sits on one.

## Verify
- `npx tsc --noEmit` — only the pre-existing `test/build-info.test.ts` NODE_ENV errors remain (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)