### PR TITLE
fix(explorer): stop network-switch nag on bridge chains

### DIFF
--- a/Makalu/explorer/components/NetworkSwitchModal.tsx
+++ b/Makalu/explorer/components/NetworkSwitchModal.tsx
@@ -9,6 +9,20 @@ import {
 const MAKALU_CHAIN_ID = 700777;
 const MAKALU_CHAIN_HEX = '0xab169';
 
+// Chains the app legitimately operates on. Makalu is the primary chain, but the
+// cross-chain bridge lets a connected wallet sit on Kamet (the other source
+// chain) or on a destination chain (Ethereum Sepolia, Base Sepolia, BNB
+// testnet) to import/view the wrapped token after a transfer. Only nag the user
+// when the wallet is on a chain outside this set — otherwise every bridge user
+// gets a "switch to Makalu" popover the moment they change networks.
+const SUPPORTED_CHAIN_IDS = new Set<number>([
+  MAKALU_CHAIN_ID, // Lithosphere Makalu
+  900523, // Lithosphere Kamet
+  11155111, // Ethereum Sepolia
+  84532, // Base Sepolia
+  97, // BNB Smart Chain Testnet
+]);
+
 const MAKALU_CHAIN_FOR_WALLET = {
   chainId: MAKALU_CHAIN_HEX,
   chainName: 'Lithosphere Makalu Testnet',
@@ -45,9 +59,9 @@ function NetworkSwitchModalContent() {
     setMounted(true);
   }, []);
 
-  // Reset dismissed state when the user disconnects or lands on Makalu
+  // Reset dismissed state when the user disconnects or lands on a supported chain
   useEffect(() => {
-    if (!isConnected || chainId === MAKALU_CHAIN_ID) {
+    if (!isConnected || (chainId != null && SUPPORTED_CHAIN_IDS.has(chainId))) {
       setDismissed(false);
     }
   }, [isConnected, chainId]);
@@ -56,7 +70,7 @@ function NetworkSwitchModalContent() {
     mounted &&
     isConnected &&
     Boolean(address) &&
-    chainId !== MAKALU_CHAIN_ID &&
+    (chainId == null || !SUPPORTED_CHAIN_IDS.has(chainId)) &&
     !dismissed;
 
   const handleSwitch = useCallback(async () => {


### PR DESCRIPTION
## The real culprit
The reported "Switch Network — This app doesn't support your current network" popover (showing only **Lithosphere Makalu Testnet** + Disconnect) is **not** Web3Modal's guard — it's the custom `components/NetworkSwitchModal.tsx`, mounted globally in `_app.tsx`. It fired on **any** chain other than Makalu 700777.

PRs #47 (Kamet) and #49 (Sepolia/Base/BNB) correctly whitelisted chains in Web3Modal's own `chains` list, but this separate hand-rolled modal kept forcing the wallet back to Makalu. The chain name it renders — "Lithosphere Makalu Testnet", which no longer exists in the Web3Modal chain config — is what gave it away.

## Why it matters now
The cross-chain bridge lets a connected wallet legitimately sit on Kamet (the other source chain) or a destination chain (Ethereum Sepolia, Base Sepolia, BNB testnet) to import/view the wrapped token after a transfer. A blanket "must be on Makalu" guard nagged every bridge user on every network change.

## Fix
Replace the single `chainId !== 700777` check with a `SUPPORTED_CHAIN_IDS` set matching the Web3Modal whitelist ({700777, 900523, 11155111, 84532, 97}). Only nag when the wallet is on a chain outside the set; still offers Makalu as the switch target for genuinely unrelated chains.

## Verify
- `npx tsc --noEmit` — clean apart from the pre-existing `test/build-info.test.ts` NODE_ENV errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)