### PR TITLE
feat(auth): server-validated Thanos sessions (/auth/me)

### DIFF
--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -6,7 +6,7 @@
  */
 import { Router, type Request, type Response } from 'express';
 import { bech32 } from 'bech32';
-import { randomBytes, createHmac } from 'node:crypto';
+import { randomBytes, createHmac, timingSafeEqual } from 'node:crypto';
 import { verifyMessage, isAddress, getAddress } from 'ethers';
 import { query, slowQuery } from './db.js';
 import { logger } from './lib/logger.js';
@@ -3206,6 +3206,51 @@ export function explorerRouter(): Router {
       logger.error({ err: err instanceof Error ? err.message : String(err) }, '[api] /auth/verify error');
       res.status(500).json({ ok: false, error: 'verification failed' });
     }
+  });
+
+  // Validate a `payload.sig` session token: constant-time HMAC check + expiry.
+  // Returns the decoded claims, or null if the token is forged/tampered/expired.
+  interface SessionClaims { sub: string; chainId: number; iat: number; exp: number }
+  const verifySession = (token: string): SessionClaims | null => {
+    const dot = token.indexOf('.');
+    if (dot <= 0) return null;
+    const payload = token.slice(0, dot);
+    const sig = token.slice(dot + 1);
+    const expected = b64url(createHmac('sha256', sessionSecret).update(payload).digest());
+    const sigBuf = Buffer.from(sig);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) return null;
+    try {
+      const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as SessionClaims;
+      if (typeof claims.exp !== 'number' || claims.exp * 1000 <= Date.now()) return null;
+      return claims;
+    } catch {
+      return null;
+    }
+  };
+
+  const bearerToken = (req: Request): string | null => {
+    const h = req.headers.authorization;
+    return typeof h === 'string' && /^Bearer\s+/i.test(h) ? h.replace(/^Bearer\s+/i, '').trim() : null;
+  };
+
+  // GET /auth/me → validate the Authorization: Bearer session and return the
+  // verified identity. This is the server-side half that makes the Thanos
+  // session real: the token is HMAC-checked here, not merely trusted from the
+  // client's localStorage. Front-ends call this on load to confirm a stored
+  // session is still valid (and to gate authenticated views).
+  r.get('/auth/me', (req: Request, res: Response) => {
+    const token = bearerToken(req);
+    if (!token) {
+      res.status(401).json({ ok: false, error: 'missing bearer token' });
+      return;
+    }
+    const claims = verifySession(token);
+    if (!claims) {
+      res.status(401).json({ ok: false, error: 'invalid or expired session' });
+      return;
+    }
+    res.json({ ok: true, address: claims.sub, chainId: claims.chainId, expiresAt: claims.exp });
   });
 
   return r;

--- a/Makalu/explorer/components/ThanosSignIn.tsx
+++ b/Makalu/explorer/components/ThanosSignIn.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from 'react';
 import { ThanosConnectButton } from 'thanos-connect/react';
 import type { ThanosSession } from 'thanos-connect';
+import {
+  clearStoredSession,
+  getStoredSession,
+  saveStoredSession,
+  validateSession,
+  type StoredSession,
+} from '@/lib/auth';
 
 /**
  * "Sign in with Thanos" — SIWE authentication via the `thanos-connect` SDK.
@@ -8,46 +15,27 @@ import type { ThanosSession } from 'thanos-connect';
  * The SDK's default endpoints (GET /api/auth/nonce?address=…, POST
  * /api/auth/verify) are exactly what the Makalu API serves, so no endpoint
  * overrides are needed. On success the API returns a session token, which we
- * persist in localStorage so the signed-in state survives reloads.
+ * persist in localStorage — and re-validate against the server (`/api/auth/me`)
+ * on mount so a stale/tampered token never shows as signed in.
  */
-
-const STORAGE_KEY = 'thanos_session';
-
-interface StoredSession {
-  address: string;
-  sessionToken: string | null;
-  expiresAt: number | null;
-}
 
 function shorten(addr: string): string {
   return addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
-}
-
-/** Notify the Header (same tab) that the sign-in state changed. */
-function notifySessionChanged() {
-  if (typeof window !== 'undefined') {
-    window.dispatchEvent(new Event('thanos-session-changed'));
-  }
 }
 
 export default function ThanosSignIn() {
   const [session, setSession] = useState<StoredSession | null>(null);
   const [error, setError] = useState('');
 
-  // Restore a non-expired session on mount.
+  // Restore a session on mount, then confirm it with the server. A token in
+  // localStorage is only a claim; /api/auth/me is the source of truth.
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return;
-      const s = JSON.parse(raw) as StoredSession;
-      if (!s.expiresAt || s.expiresAt * 1000 > Date.now()) {
-        setSession(s);
-      } else {
-        localStorage.removeItem(STORAGE_KEY);
-      }
-    } catch {
-      /* ignore malformed storage */
-    }
+    const stored = getStoredSession();
+    if (!stored) return;
+    setSession(stored); // optimistic — avoids a flash of the signed-out button
+    void validateSession().then((identity) => {
+      if (!identity) setSession(null); // validateSession already cleared storage
+    });
   }, []);
 
   function handleSignIn(s: ThanosSession) {
@@ -59,23 +47,13 @@ export default function ThanosSignIn() {
     };
     setSession(stored);
     setError('');
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
-    } catch {
-      /* storage may be unavailable (private mode) — session stays in memory */
-    }
-    notifySessionChanged();
+    saveStoredSession(stored);
   }
 
   function signOut() {
     setSession(null);
     setError('');
-    try {
-      localStorage.removeItem(STORAGE_KEY);
-    } catch {
-      /* ignore */
-    }
-    notifySessionChanged();
+    clearStoredSession();
   }
 
   if (session) {

--- a/Makalu/explorer/lib/auth.ts
+++ b/Makalu/explorer/lib/auth.ts
@@ -1,0 +1,103 @@
+/**
+ * Thanos SIWE session helpers (client side).
+ *
+ * The `thanos-connect` sign-in mints an HMAC session token that the API's
+ * `/api/auth/verify` returns. We persist it in localStorage so the signed-in
+ * state survives reloads — but a token in localStorage is only a *claim*. The
+ * server is the source of truth: `validateSession()` calls `/api/auth/me` with
+ * the Bearer token so a tampered/expired/forged token is rejected, not merely
+ * trusted. Use `authHeaders()` to attach the token to any authenticated fetch.
+ */
+
+export const THANOS_SESSION_KEY = 'thanos_session';
+export const THANOS_SESSION_EVENT = 'thanos-session-changed';
+
+export interface StoredSession {
+  address: string;
+  sessionToken: string | null;
+  expiresAt: number | null; // unix seconds
+}
+
+export interface VerifiedIdentity {
+  address: string;
+  chainId: number;
+  expiresAt: number; // unix seconds
+}
+
+/** Read the persisted session, dropping it if the local expiry has passed. */
+export function getStoredSession(): StoredSession | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(THANOS_SESSION_KEY);
+    if (!raw) return null;
+    const s = JSON.parse(raw) as StoredSession;
+    if (s.expiresAt && s.expiresAt * 1000 <= Date.now()) {
+      localStorage.removeItem(THANOS_SESSION_KEY);
+      return null;
+    }
+    return s;
+  } catch {
+    return null;
+  }
+}
+
+export function saveStoredSession(s: StoredSession): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(THANOS_SESSION_KEY, JSON.stringify(s));
+  } catch {
+    /* storage may be unavailable (private mode) — caller keeps it in memory */
+  }
+  notifySessionChanged();
+}
+
+export function clearStoredSession(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(THANOS_SESSION_KEY);
+  } catch {
+    /* ignore */
+  }
+  notifySessionChanged();
+}
+
+/** Authorization header for authenticated API calls (empty when signed out). */
+export function authHeaders(): Record<string, string> {
+  const s = getStoredSession();
+  return s?.sessionToken ? { Authorization: `Bearer ${s.sessionToken}` } : {};
+}
+
+/** Notify same-tab listeners (e.g. the Header) that the session changed. */
+export function notifySessionChanged(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(THANOS_SESSION_EVENT));
+  }
+}
+
+/**
+ * Confirm a stored session with the server. Returns the verified identity, or
+ * null (and clears the stored session) if the token is invalid/expired. This is
+ * what turns "a token in localStorage" into real, server-checked auth.
+ */
+export async function validateSession(): Promise<VerifiedIdentity | null> {
+  const s = getStoredSession();
+  if (!s?.sessionToken) return null;
+  try {
+    const res = await fetch('/api/auth/me', {
+      headers: { Authorization: `Bearer ${s.sessionToken}` },
+    });
+    if (!res.ok) {
+      clearStoredSession();
+      return null;
+    }
+    const body = (await res.json()) as { ok?: boolean } & VerifiedIdentity;
+    if (!body.ok) {
+      clearStoredSession();
+      return null;
+    }
+    return { address: body.address, chainId: body.chainId, expiresAt: body.expiresAt };
+  } catch {
+    // Network error — leave the stored session in place; treat as unverified.
+    return null;
+  }
+}


### PR DESCRIPTION
## Context
Thanos wallet is now [live on the Chrome Web Store](https://chromewebstore.google.com/detail/thanos-wallet/jajfgpnlaoakklhnnchdpiglmkkpcehj), so "Sign in with Thanos" (SIWE via `thanos-connect`) is finally testable end-to-end. I verified the existing sign-in ceremony against the real SDK v0.1.0 contract — paths (`/api/auth/nonce`, `/api/auth/verify`), EIP-6963 RDNS `fi.thanos.wallet`, SIWE labels (`Nonce:`/`Chain ID:`), and the verify body/response all match, and both live endpoints work.

## The gap this closes
The flow minted a session token but **nothing consumed it** — no server-side validation, and the client trusted its own localStorage. That's sign-in theater, not auth.

## Changes
**API** (`routes.ts`)
- `verifySession()` — constant-time HMAC check (`timingSafeEqual`) + expiry.
- `GET /auth/me` — validates the `Authorization: Bearer` session token, returns the verified identity `{ address, chainId, expiresAt }`.

**Explorer**
- `lib/auth.ts` — shared session helpers: `getStoredSession`/`saveStoredSession`/`clearStoredSession`, `authHeaders()` for authenticated fetches, and `validateSession()` which calls `/api/auth/me`.
- `ThanosSignIn.tsx` — re-validates a restored session against the server on mount and drops it if stale/tampered, instead of trusting localStorage.

## Verification
Offline round-trip against the **real** `thanos-connect` SDK: `buildSiweMessage` → ethers `signMessage` → server verify regex → session mint → `verifySession`, plus the security negatives — tampered signature, wrong-secret token, expired session, garbage token, and wrong-signer attack all rejected. **11/11 green.** API + explorer `tsc --noEmit` clean (only pre-existing `build-info.test.ts` errors remain).

This is the foundation (server-verified sessions + `/auth/me` + Bearer plumbing). Gating a specific feature (faucet, a personalized "My account" view) can build on `authHeaders()`/`requireAuth` next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)