### PR TITLE
docs(openapi): document GET /auth/me + regen SDK

### DIFF
--- a/Makalu/packages/sdk/src/generated/openapi.ts
+++ b/Makalu/packages/sdk/src/generated/openapi.ts
@@ -175,6 +175,49 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Validate the Bearer session token and return the verified identity. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Verified identity ({ ok, address, chainId, expiresAt }). */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["JsonObject"];
+                    };
+                };
+                /** @description Missing */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/nonce": {
         parameters: {
             query?: never;

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -41,6 +41,11 @@ tags:
   - name: Litho (demo)
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: 'Thanos SIWE session token from /auth/verify, sent as `Authorization: Bearer <token>`.'
   parameters:
     LimitQuery:
       name: limit
@@ -496,6 +501,19 @@ paths:
               schema: { $ref: '#/components/schemas/JsonObject' }
         '400': { description: Missing or invalid fields. }
         '401': { description: Bad signature or invalid/expired nonce. }
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: Validate the Bearer session token and return the verified identity.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Verified identity ({ ok, address, chainId, expiresAt }).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/JsonObject' }
+        '401': { description: Missing, invalid, or expired session token. }
 
   # ───── Litho (demo router, kept for backwards-compat with early SDKs) ────
   /litho/:


### PR DESCRIPTION
## Why
`GET /auth/me` (server-verified Thanos sessions, PR #51) was added to the API without a matching `openapi.yaml` entry, so the **verify-openapi-in-sync** drift gate failed the deploy:

```
Routes registered in code but missing from openapi.yaml (1):
  + GET /auth/me
```

## Fix
- Add the `/auth/me` `paths:` entry (Auth tag, `bearerAuth` security, 200 identity / 401).
- Add a `bearerAuth` `securityScheme` under `components` (was referenced but undefined).
- Regenerate the SDK's `src/generated/openapi.ts` so **verify-openapi-codegen** stays clean.

## Verify
- `pnpm run verify-openapi-in-sync` → **in sync (34 endpoints)**.
- `node scripts/codegen-openapi.mjs` → regenerated cleanly; `/auth/me` present in generated SDK.
- (Fixed an intermediate YAML parse error — an unquoted `Authorization: Bearer` colon in the scheme description; now quoted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)