### PR TITLE
feat(faucet): gate claims behind Thanos sign-in

### DIFF
--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -1420,6 +1420,73 @@ function mapValidator(r: ValidatorRow) {
 export function explorerRouter(): Router {
   const r = Router();
 
+  // ── Thanos SIWE auth foundation ─────────────────────────────────────────────
+  // Helpers used by both the /auth/* routes and the faucet claim gate: a stable
+  // HMAC session secret, one-time nonce store, and mint/verify/bearer helpers.
+  // Defined up here (not next to the routes) so earlier routes — the faucet —
+  // can require a session without a use-before-declaration hazard.
+  const AUTH_SESSION_TTL_SEC = 24 * 60 * 60; // 24h session
+  const AUTH_NONCE_TTL_MS = 10 * 60 * 1000; // 10 min nonce
+  const AUTH_ALLOWED_CHAIN = 700777;
+
+  // A stable secret keeps sessions valid across restarts; without one we fall
+  // back to an ephemeral per-process secret (sessions reset on restart).
+  const sessionSecret = process.env.AUTH_SESSION_SECRET || randomBytes(32).toString('hex');
+  if (!process.env.AUTH_SESSION_SECRET) {
+    logger.warn('[api] AUTH_SESSION_SECRET not set — using an ephemeral secret; Thanos sessions reset on restart');
+  }
+
+  // One-time nonce store: nonce → { address(lowercased), expiresAt }.
+  const authNonces = new Map<string, { address: string; expiresAt: number }>();
+  const pruneNonces = () => {
+    const now = Date.now();
+    for (const [n, v] of authNonces) if (v.expiresAt <= now) authNonces.delete(n);
+  };
+
+  const b64url = (buf: Buffer): string =>
+    buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  interface SessionClaims { sub: string; chainId: number; iat: number; exp: number }
+
+  const signSession = (address: string): { token: string; expiresAt: number } => {
+    const now = Math.floor(Date.now() / 1000);
+    const exp = now + AUTH_SESSION_TTL_SEC;
+    const payload = b64url(Buffer.from(JSON.stringify({ sub: address, chainId: AUTH_ALLOWED_CHAIN, iat: now, exp })));
+    const sig = b64url(createHmac('sha256', sessionSecret).update(payload).digest());
+    return { token: `${payload}.${sig}`, expiresAt: exp };
+  };
+
+  // Validate a `payload.sig` session token: constant-time HMAC check + expiry.
+  // Returns the decoded claims, or null if the token is forged/tampered/expired.
+  const verifySession = (token: string): SessionClaims | null => {
+    const dot = token.indexOf('.');
+    if (dot <= 0) return null;
+    const payload = token.slice(0, dot);
+    const sig = token.slice(dot + 1);
+    const expected = b64url(createHmac('sha256', sessionSecret).update(payload).digest());
+    const sigBuf = Buffer.from(sig);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) return null;
+    try {
+      const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as SessionClaims;
+      if (typeof claims.exp !== 'number' || claims.exp * 1000 <= Date.now()) return null;
+      return claims;
+    } catch {
+      return null;
+    }
+  };
+
+  const bearerToken = (req: Request): string | null => {
+    const h = req.headers.authorization;
+    return typeof h === 'string' && /^Bearer\s+/i.test(h) ? h.replace(/^Bearer\s+/i, '').trim() : null;
+  };
+
+  // Verified session claims for a request, or null if unauthenticated/invalid.
+  const sessionFromRequest = (req: Request): SessionClaims | null => {
+    const token = bearerToken(req);
+    return token ? verifySession(token) : null;
+  };
+
   // ── Stats summary (homepage) ────────────────────────────────────────────
 
   r.get('/stats/summary', async (_req: Request, res: Response) => {
@@ -2901,6 +2968,14 @@ export function explorerRouter(): Router {
       const normalizedAddress = typeof address === 'string' ? address.trim() : '';
       const normalizedAmount = normalizeFaucetAmountInput(amount);
 
+      // Gate: the faucet claim requires a valid Thanos SIWE session (anti-abuse).
+      const session = sessionFromRequest(req);
+      if (!session) {
+        audit({ action: 'faucet_claim_rejected', reason: 'unauthenticated' }, 'no valid session');
+        res.status(401).json({ ok: false, message: 'Sign in with Thanos to claim from the faucet.' });
+        return;
+      }
+
       if (!normalizedAddress) {
         logger.warn('[api] Rejecting faucet claim: missing address');
         audit({ action: 'faucet_claim_rejected', reason: 'missing_address' }, 'missing address');
@@ -2930,6 +3005,20 @@ export function explorerRouter(): Router {
           'non-EVM address',
         );
         res.status(400).json({ ok: false, message: 'The faucet currently supports EVM (0x) addresses only. Please use your 0x address.' });
+        return;
+      }
+
+      // Bind the claim to the signed-in identity: you may only fund the address
+      // you proved you control via Thanos sign-in.
+      if (getAddress(normalizedAddress) !== getAddress(session.sub)) {
+        audit(
+          { action: 'faucet_claim_rejected', reason: 'address_mismatch', actor: getAddress(session.sub) },
+          'claim address does not match session',
+        );
+        res.status(403).json({
+          ok: false,
+          message: 'You can only claim to the address you signed in with.',
+        });
         return;
       }
 
@@ -3105,38 +3194,11 @@ export function explorerRouter(): Router {
     void proxyBridgeGet(`/bridge/transactions/${a}`, res);
   });
 
-  // ── Sign in with Thanos (SIWE auth) ─────────────────────────────────────────
-  // Backend half of the `thanos-connect` flow: issue a one-time nonce, then
-  // verify the signed SIWE message and mint a session token. The SDK calls these
-  // exact default paths (GET /auth/nonce?address=…, POST /auth/verify).
-  const AUTH_SESSION_TTL_SEC = 24 * 60 * 60; // 24h session
-  const AUTH_NONCE_TTL_MS = 10 * 60 * 1000; // 10 min nonce
-  const AUTH_ALLOWED_CHAIN = 700777;
-
-  // A stable secret keeps sessions valid across restarts; without one we fall
-  // back to an ephemeral per-process secret (sessions reset on restart).
-  const sessionSecret = process.env.AUTH_SESSION_SECRET || randomBytes(32).toString('hex');
-  if (!process.env.AUTH_SESSION_SECRET) {
-    logger.warn('[api] AUTH_SESSION_SECRET not set — using an ephemeral secret; Thanos sessions reset on restart');
-  }
-
-  // One-time nonce store: nonce → { address(lowercased), expiresAt }.
-  const authNonces = new Map<string, { address: string; expiresAt: number }>();
-  const pruneNonces = () => {
-    const now = Date.now();
-    for (const [n, v] of authNonces) if (v.expiresAt <= now) authNonces.delete(n);
-  };
-
-  const b64url = (buf: Buffer): string =>
-    buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-
-  const signSession = (address: string): { token: string; expiresAt: number } => {
-    const now = Math.floor(Date.now() / 1000);
-    const exp = now + AUTH_SESSION_TTL_SEC;
-    const payload = b64url(Buffer.from(JSON.stringify({ sub: address, chainId: AUTH_ALLOWED_CHAIN, iat: now, exp })));
-    const sig = b64url(createHmac('sha256', sessionSecret).update(payload).digest());
-    return { token: `${payload}.${sig}`, expiresAt: exp };
-  };
+  // ── Sign in with Thanos (SIWE auth) routes ──────────────────────────────────
+  // Backend half of the `thanos-connect` flow. Helpers (sessionSecret, nonce
+  // store, signSession, verifySession, bearerToken) live in the auth foundation
+  // block near the top of explorerRouter(). The SDK calls these exact default
+  // paths (GET /auth/nonce?address=…, POST /auth/verify).
 
   // GET /auth/nonce?address=0x… → text/plain nonce (per the thanos-connect contract).
   r.get('/auth/nonce', (req: Request, res: Response) => {
@@ -3207,32 +3269,6 @@ export function explorerRouter(): Router {
       res.status(500).json({ ok: false, error: 'verification failed' });
     }
   });
-
-  // Validate a `payload.sig` session token: constant-time HMAC check + expiry.
-  // Returns the decoded claims, or null if the token is forged/tampered/expired.
-  interface SessionClaims { sub: string; chainId: number; iat: number; exp: number }
-  const verifySession = (token: string): SessionClaims | null => {
-    const dot = token.indexOf('.');
-    if (dot <= 0) return null;
-    const payload = token.slice(0, dot);
-    const sig = token.slice(dot + 1);
-    const expected = b64url(createHmac('sha256', sessionSecret).update(payload).digest());
-    const sigBuf = Buffer.from(sig);
-    const expBuf = Buffer.from(expected);
-    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) return null;
-    try {
-      const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as SessionClaims;
-      if (typeof claims.exp !== 'number' || claims.exp * 1000 <= Date.now()) return null;
-      return claims;
-    } catch {
-      return null;
-    }
-  };
-
-  const bearerToken = (req: Request): string | null => {
-    const h = req.headers.authorization;
-    return typeof h === 'string' && /^Bearer\s+/i.test(h) ? h.replace(/^Bearer\s+/i, '').trim() : null;
-  };
 
   // GET /auth/me → validate the Authorization: Bearer session and return the
   // verified identity. This is the server-side half that makes the Thanos

--- a/Makalu/explorer/pages/faucet.tsx
+++ b/Makalu/explorer/pages/faucet.tsx
@@ -4,6 +4,7 @@ import { useWeb3Modal, useWeb3ModalAccount, useWeb3ModalProvider } from '@web3mo
 import { EXPLORER_TITLE } from '@/lib/constants';
 import { isEvmAddress } from '@/lib/format';
 import { isEvmTxHash } from '@/lib/tx';
+import { authHeaders, validateSession, THANOS_SESSION_EVENT } from '@/lib/auth';
 
 type SelectOption = {
   value: string;
@@ -218,6 +219,7 @@ function FaucetContent() {
   const [cooldownHours, setCooldownHours] = useState(24);
   const [mounted, setMounted] = useState(false);
   const [isAddingNetwork, setIsAddingNetwork] = useState(false);
+  const [signedInAddress, setSignedInAddress] = useState<string | null>(null);
   const pendingNetworkAdd = useRef(false);
 
   const selectedAsset = useMemo(() => {
@@ -243,7 +245,13 @@ function FaucetContent() {
   const normalizedAddress = address.trim();
   const isValidRecipientAddress = isEvmAddress(normalizedAddress);
   const amountIsValid = selectedAsset.allowedAmounts.includes(amount);
-  const canSubmitClaim = isValidRecipientAddress && amountIsValid && !claiming;
+  const isSignedIn = Boolean(signedInAddress);
+  // The API binds a claim to the signed-in identity — you may only fund the
+  // address you proved you control via Thanos sign-in.
+  const addressMatchesSession =
+    !signedInAddress || normalizedAddress.toLowerCase() === signedInAddress.toLowerCase();
+  const canSubmitClaim =
+    isValidRecipientAddress && amountIsValid && isSignedIn && addressMatchesSession && !claiming;
   const addressHelpText = normalizedAddress
     ? (
       isValidRecipientAddress
@@ -262,6 +270,25 @@ function FaucetContent() {
     }
     setConnectedAddress(null);
   }, [isConnected, walletAddress]);
+
+  // Reflect the Thanos SIWE session — the faucet claim is gated behind sign-in,
+  // and the server validates the token, so confirm it against /api/auth/me.
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      void validateSession().then((identity) => {
+        if (!cancelled) setSignedInAddress(identity?.address ?? null);
+      });
+    };
+    refresh();
+    window.addEventListener(THANOS_SESSION_EVENT, refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(THANOS_SESSION_EVENT, refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -378,12 +405,22 @@ function FaucetContent() {
       return;
     }
 
+    if (!signedInAddress) {
+      showStatus('Sign in with Thanos to claim from the faucet.', 'error');
+      return;
+    }
+
+    if (normalizedAddress.toLowerCase() !== signedInAddress.toLowerCase()) {
+      showStatus(`You can only claim to the address you signed in with (${signedInAddress}).`, 'error');
+      return;
+    }
+
     setClaiming(true);
 
     try {
       const res = await fetch('/api/faucet/claim', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({
           address: normalizedAddress,
           assetId: selectedAsset.id,
@@ -562,6 +599,31 @@ function FaucetContent() {
                     </p>
                   </div>
                 </div>
+
+                {!isSignedIn ? (
+                  <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-4 text-sm text-amber-200/90">
+                    Faucet claims require sign-in.{' '}
+                    <a href="/signin" className="font-medium text-white underline underline-offset-4">
+                      Sign in with Thanos
+                    </a>{' '}
+                    to prove you control the address you&apos;re funding, then claim.
+                  </div>
+                ) : (
+                  !addressMatchesSession && (
+                    <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-4 text-sm text-amber-200/90">
+                      You&apos;re signed in as{' '}
+                      <span className="break-all font-medium text-white">{signedInAddress}</span> — the faucet
+                      can only fund that address.{' '}
+                      <button
+                        type="button"
+                        onClick={() => signedInAddress && setAddress(signedInAddress)}
+                        className="font-medium text-white underline underline-offset-4"
+                      >
+                        Use it
+                      </button>
+                    </div>
+                  )
+                )}
 
                 <div className="flex flex-wrap gap-3 pt-2">
                   <button

--- a/Makalu/packages/sdk/src/generated/openapi.ts
+++ b/Makalu/packages/sdk/src/generated/openapi.ts
@@ -696,7 +696,7 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** Request a testnet LITHO drip for an address. */
+        /** Request a testnet LITHO drip for an address. Requires a Thanos SIWE session. */
         post: {
             parameters: {
                 query?: never;
@@ -707,7 +707,7 @@ export type paths = {
             requestBody: {
                 content: {
                     "application/json": {
-                        /** @description Recipient (hex or bech32). */
+                        /** @description Recipient (hex or bech32). Must equal the signed-in address. */
                         address: string;
                         /** @description hCaptcha token if enabled. */
                         captcha?: string;
@@ -724,6 +724,20 @@ export type paths = {
                 };
                 /** @description Validation error (bad address */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Missing or invalid Thanos session token. */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Claim address does not match the signed-in address. */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -378,7 +378,9 @@ paths:
   /faucet/claim:
     post:
       tags: [Faucet]
-      summary: Request a testnet LITHO drip for an address.
+      summary: Request a testnet LITHO drip for an address. Requires a Thanos SIWE session.
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -387,11 +389,13 @@ paths:
               type: object
               required: [address]
               properties:
-                address: { type: string, description: Recipient (hex or bech32). }
+                address: { type: string, description: Recipient (hex or bech32). Must equal the signed-in address. }
                 captcha: { type: string, description: hCaptcha token if enabled. }
       responses:
         '200': { description: Drip submitted. Response includes tx hash. }
         '400': { description: Validation error (bad address, missing captcha). }
+        '401': { description: Missing or invalid Thanos session token. }
+        '403': { description: Claim address does not match the signed-in address. }
         '429': { description: Cooldown active for this address / IP. }
 
   # ───── MultX Bridge (same-origin proxy to bridge.litho.ai) ────


### PR DESCRIPTION
## What
Faucet claims now require a valid **Thanos SIWE session**, and a claim can only fund the **address you signed in with** — turning the `/auth/me` foundation into real access control and cutting faucet abuse.

## API (`routes.ts`)
- Hoisted the SIWE auth foundation (`sessionSecret`, `signSession`, `verifySession`, `bearerToken`, + new `sessionFromRequest`) to the top of `explorerRouter()` so the earlier faucet route can require a session with no use-before-declaration hazard. (Pure move — `/auth/*` behaviour unchanged.)
- `POST /faucet/claim`: **401** when unauthenticated, **403** when the claim address ≠ signed-in address; both rejections audited.

## Explorer (`faucet.tsx`)
- Confirms the stored session against `/api/auth/me`, attaches the Bearer token to the claim.
- Disables submit + shows a **'Sign in with Thanos'** notice when signed out; offers **'Use it'** to snap the recipient to the signed-in address on mismatch.

## Docs / SDK
- `/faucet/claim` now documents `bearerAuth` + 401/403; SDK `openapi.ts` regenerated.

## Verify
- api + explorer `tsc --noEmit` clean.
- `verify-openapi-in-sync` → in sync (34 endpoints); SDK codegen clean.
- Post-deploy I'll confirm live: no-token → 401, valid-token+mismatched-address → 403 (won't trigger a real drip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)