### PR TITLE
fix(thanos): sign SIWE via hex payload to dodge extension BytesLike bug

### DIFF
--- a/Makalu/explorer/components/ThanosSignIn.tsx
+++ b/Makalu/explorer/components/ThanosSignIn.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { ThanosConnectButton } from 'thanos-connect/react';
-import type { ThanosSession } from 'thanos-connect';
+import { buildSiweMessage, discoverThanos } from 'thanos-connect';
+import { getAddress, hexlify, toUtf8Bytes } from 'ethers';
 import {
   clearStoredSession,
   getStoredSession,
@@ -10,22 +10,108 @@ import {
 } from '@/lib/auth';
 
 /**
- * "Sign in with Thanos" — SIWE authentication via the `thanos-connect` SDK.
+ * "Sign in with Thanos" — SIWE authentication.
  *
- * The SDK's default endpoints (GET /api/auth/nonce?address=…, POST
- * /api/auth/verify) are exactly what the Makalu API serves, so no endpoint
- * overrides are needed. On success the API returns a session token, which we
- * persist in localStorage — and re-validate against the server (`/api/auth/me`)
- * on mount so a stale/tampered token never shows as signed in.
+ * We drive the flow directly (discover → nonce → build SIWE → personal_sign →
+ * verify) instead of using the SDK's <ThanosConnectButton>, for ONE reason:
+ * the button hands the raw SIWE *string* to `personal_sign`, and the current
+ * Thanos extension mis-serialises that into a byte-map object, so its own
+ * ethers call throws `invalid BytesLike value (value={"0":…})` and the signature
+ * never completes. Passing a `0x`-hex payload instead signs the exact same bytes
+ * (the UTF-8 encoding of the message) but sidesteps the extension's bug. The
+ * server still verifies with `verifyMessage(message, signature)` because the
+ * signed bytes are identical.
+ *
+ * Endpoints (GET /api/auth/nonce?address=…, POST /api/auth/verify) are the API's
+ * defaults; on success we persist the session and re-validate it against
+ * /api/auth/me on mount.
  */
+
+const APP_NAME = 'Lithosphere Makalu Explorer';
+const CHAIN_ID = 700777;
+const CHAIN_HEX = '0xab169';
+const THANOS_RDNS = 'fi.thanos.wallet';
 
 function shorten(addr: string): string {
   return addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
 }
 
+function messageOf(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const e = err as { code?: number | string; message?: string };
+    if (e.code === 4001 || e.code === 'ACTION_REJECTED') {
+      return 'Signature request was cancelled in the wallet.';
+    }
+    if (typeof e.message === 'string' && e.message) return e.message;
+  }
+  return 'Sign-in failed. Please try again.';
+}
+
+async function signInWithHexPayload(): Promise<StoredSession> {
+  const discovered = await discoverThanos({ walletRdns: THANOS_RDNS });
+  if (!discovered) {
+    throw new Error('Thanos wallet not found. Install the Thanos extension, then reload this page.');
+  }
+  const provider = discovered.provider;
+
+  const accounts = (await provider.request({ method: 'eth_requestAccounts' })) as string[];
+  if (!accounts?.length) throw new Error('No account was returned by the wallet.');
+  const address = getAddress(accounts[0]);
+
+  // Best-effort: make sure the wallet is on Makalu. Thanos has it built in and
+  // treats this as a no-op; failures are non-fatal.
+  try {
+    await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: CHAIN_HEX }] });
+  } catch {
+    /* ignore — user can still sign */
+  }
+
+  const nonce = (await (await fetch(`/api/auth/nonce?address=${address}`)).text()).trim();
+
+  const message = buildSiweMessage({
+    domain: window.location.host,
+    address,
+    uri: window.location.origin,
+    statement: `Sign in to ${APP_NAME} with your Thanos Wallet.`,
+    chainId: CHAIN_ID,
+    nonce,
+  });
+
+  // The fix: sign a 0x-hex payload (the UTF-8 bytes of the message) rather than
+  // the raw string. Same bytes signed → server verifyMessage() still recovers
+  // the signer, but the extension no longer chokes on a serialised byte-array.
+  const hexMessage = hexlify(toUtf8Bytes(message));
+  const signature = (await provider.request({
+    method: 'personal_sign',
+    params: [hexMessage, address],
+  })) as string;
+
+  const res = await fetch('/api/auth/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message, signature, address }),
+  });
+  const body = (await res.json()) as {
+    ok?: boolean;
+    error?: string;
+    address?: string;
+    sessionToken?: string | null;
+    expiresAt?: number | null;
+  };
+  if (!res.ok || !body.ok) {
+    throw new Error(body.error || 'Sign-in verification failed.');
+  }
+  return {
+    address: body.address ?? address,
+    sessionToken: body.sessionToken ?? null,
+    expiresAt: body.expiresAt ?? null,
+  };
+}
+
 export default function ThanosSignIn() {
   const [session, setSession] = useState<StoredSession | null>(null);
   const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
 
   // Restore a session on mount, then confirm it with the server. A token in
   // localStorage is only a claim; /api/auth/me is the source of truth.
@@ -38,16 +124,18 @@ export default function ThanosSignIn() {
     });
   }, []);
 
-  function handleSignIn(s: ThanosSession) {
-    const raw = s.raw as { expiresAt?: number } | undefined;
-    const stored: StoredSession = {
-      address: s.address,
-      sessionToken: s.sessionToken,
-      expiresAt: raw?.expiresAt ?? null,
-    };
-    setSession(stored);
+  async function handleSignIn() {
     setError('');
-    saveStoredSession(stored);
+    setBusy(true);
+    try {
+      const stored = await signInWithHexPayload();
+      setSession(stored);
+      saveStoredSession(stored);
+    } catch (err) {
+      setError(messageOf(err));
+    } finally {
+      setBusy(false);
+    }
   }
 
   function signOut() {
@@ -80,11 +168,13 @@ export default function ThanosSignIn() {
 
   return (
     <div>
-      <ThanosConnectButton
-        config={{ appName: 'Lithosphere Makalu Explorer', chainId: 700777 }}
-        onSignIn={handleSignIn}
-        onError={(e) => setError(e.message)}
-      />
+      <button
+        onClick={handleSignIn}
+        disabled={busy}
+        className="inline-flex items-center gap-2 rounded-2xl border border-sky-300/20 bg-gradient-to-r from-[#6d5cff] to-[#227dff] px-5 py-3 text-sm font-medium text-white shadow-[0_18px_40px_rgba(37,99,235,0.35)] transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
+      >
+        {busy ? 'Signing in…' : 'Sign in with Thanos'}
+      </button>
       {error && (
         <p className="mt-3 rounded-xl border border-red-400/20 bg-red-400/10 px-4 py-2 text-sm text-red-200">
           {error}


### PR DESCRIPTION
## Bug
On `/signin`, the Thanos wallet popup errors with **`invalid BytesLike value (argument="value", value={"0":105,"1":103,…})`** and the signature never completes. Root cause: the `thanos-connect` `<ThanosConnectButton>` passes the raw SIWE **string** to `personal_sign`; the Thanos extension serialises it into a byte-map object internally and its own ethers call rejects it. (Extension-side bug — reported to the Thanos team separately.)

## Workaround
Drive the sign-in flow directly (`discoverThanos` → nonce → `buildSiweMessage` → `personal_sign` → `/api/auth/verify`) and sign a **0x-hex payload** — `hexlify(toUtf8Bytes(message))` — instead of the string. The wallet signs the exact same bytes (the UTF-8 encoding of the message), so the API's `verifyMessage(message, signature)` still recovers the signer, but the extension no longer chokes on a serialised byte array.

## Verification
Offline, against the real `thanos-connect` SDK + ethers:
- `hexMessage` decodes to the SIWE message (`0x6d616b616c752e6c69…` = "makalu.li…").
- hex-bytes signature **===** string signature; `verifyMessage(message, sig)` recovers the address. ✅
- explorer `tsc --noEmit` clean.

⚠️ The final popup click-through can only be confirmed with the live extension (not CI-automatable) — needs a manual test on `/signin` after deploy. Sign-in is **optional** (the faucet gate was removed), so this is not airdrop-blocking; it restores the `/signin` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)