### PR TITLE
fix(thanos): normalize wallet signature return before verify

### DIFF
--- a/Makalu/explorer/components/ThanosSignIn.tsx
+++ b/Makalu/explorer/components/ThanosSignIn.tsx
@@ -36,6 +36,41 @@ function shorten(addr: string): string {
   return addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
 }
 
+/**
+ * Coerce whatever the wallet returns from personal_sign into a `0x` signature
+ * string. Most providers resolve a plain hex string, but some wrap it
+ * ({ signature }, { result }, …); if we POST a non-string the API rejects it
+ * with "message, signature, and address are required". Returns null if no
+ * usable signature is present.
+ */
+function normalizeSignature(raw: unknown): string | null {
+  if (typeof raw === 'string') {
+    const s = raw.trim();
+    if (!s) return null;
+    return s.startsWith('0x') ? s : `0x${s}`;
+  }
+  if (raw && typeof raw === 'object') {
+    const o = raw as Record<string, unknown>;
+    for (const key of ['signature', 'result', 'sig', 'data', 'value']) {
+      if (o[key] != null) {
+        const nested = normalizeSignature(o[key]);
+        if (nested) return nested;
+      }
+    }
+  }
+  return null;
+}
+
+function describeShape(raw: unknown): string {
+  if (raw === undefined) return 'undefined';
+  if (raw === null) return 'null';
+  if (typeof raw === 'object') {
+    const keys = Object.keys(raw as object);
+    return keys.length ? `object{${keys.join(',')}}` : 'empty object';
+  }
+  return typeof raw;
+}
+
 function messageOf(err: unknown): string {
   if (typeof err === 'object' && err !== null) {
     const e = err as { code?: number | string; message?: string };
@@ -81,10 +116,17 @@ async function signInWithHexPayload(): Promise<StoredSession> {
   // the raw string. Same bytes signed → server verifyMessage() still recovers
   // the signer, but the extension no longer chokes on a serialised byte-array.
   const hexMessage = hexlify(toUtf8Bytes(message));
-  const signature = (await provider.request({
+  const raw = await provider.request({
     method: 'personal_sign',
     params: [hexMessage, address],
-  })) as string;
+  });
+  const signature = normalizeSignature(raw);
+  if (!signature) {
+    throw new Error(
+      `The wallet did not return a signature (${describeShape(raw)}). ` +
+        'Update the Thanos extension to the latest version and try again.',
+    );
+  }
 
   const res = await fetch('/api/auth/verify', {
     method: 'POST',


### PR DESCRIPTION
Follow-up to #55. The hex payload cleared the extension's `invalid BytesLike` error, but sign-in then hit the API's `message, signature, and address are required` (400) — `personal_sign` resolved to a non-string, and `JSON.stringify` drops undefined fields from the POST body.

- Normalize the `personal_sign` return into a `0x` signature string, unwrapping common shapes (`{signature}`/`{result}`/`{sig}`/`{data}`/`{value}`).
- If none is usable, throw a diagnostic that names the actual shape (e.g. `undefined` / `object{…}`) instead of the server's generic 400 — so any remaining failure is conclusive.

Sign-in is optional (faucet gate removed), so not airdrop-blocking. explorer `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)