### PR TITLE
feat(explorer): show Lithosphere bech32 addresses ahead of EVM

### DIFF
--- a/Makalu/explorer/components/Header.tsx
+++ b/Makalu/explorer/components/Header.tsx
@@ -10,7 +10,7 @@ import {
 } from '@web3modal/ethers/react';
 import SearchBar from './SearchBar';
 import { EXPLORER_TITLE } from '@/lib/constants';
-import { formatValue } from '@/lib/format';
+import { formatValue, preferLitho } from '@/lib/format';
 import { apiFetch } from '@/lib/api';
 
 const THANOS_SESSION_KEY = 'thanos_session';
@@ -53,7 +53,10 @@ const MORE_ITEMS: NavItem[] = [
 function shortenAddress(value: string | null | undefined): string {
   if (!value) return '';
   if (value.length < 12) return value;
-  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+  // `litho1` is shared by every bech32 address, so keep a longer head or they
+  // all collapse to the same `litho1...` label.
+  const head = value.startsWith('litho1') ? 10 : 6;
+  return `${value.slice(0, head)}...${value.slice(-4)}`;
 }
 
 function HeaderContent() {
@@ -75,6 +78,9 @@ function HeaderContent() {
   const { address, isConnected, chainId } = useWeb3ModalAccount();
   const { walletProvider } = useWeb3ModalProvider();
   const isOnMakalu = chainId === MAKALU_CHAIN_ID;
+  // Litho-first: surface the native bech32 identity everywhere the wallet is
+  // shown. Falls back to the raw 0x value if conversion ever fails.
+  const lithoAddress = preferLitho(address);
   const balanceText = balanceLoading ? 'Refreshing...' : (lithoBalance ?? 'Unavailable');
 
   const isActive = (href: string) => {
@@ -455,14 +461,14 @@ function HeaderContent() {
           <div className="mx-auto mt-2 w-fit max-w-full rounded-[100px] border border-white/5 bg-white/[0.03] px-3 py-1.5 transition hover:bg-white/[0.05]">
             <div className="flex items-center gap-3">
               <span className="h-8 w-8 rounded-full bg-gradient-to-br from-violet-200 to-violet-500 shadow-[0_0_24px_rgba(168,85,247,0.35)]" />
-              <span className="font-semibold text-lg tracking-tight text-white/90">
-                {shortenAddress(address)}
+              <span className="font-semibold text-lg tracking-tight text-white/90" title={lithoAddress}>
+                {shortenAddress(lithoAddress)}
               </span>
               <button
                 type="button"
                 onClick={async () => {
                   try {
-                    await navigator.clipboard.writeText(address);
+                    await navigator.clipboard.writeText(lithoAddress);
                   } catch {
                     // no-op
                   }
@@ -481,7 +487,7 @@ function HeaderContent() {
           <div className="mt-5 text-center text-4xl font-semibold text-white/90 tracking-tight">{`\u{1D543}${balanceDisplay}`}</div>
 
           <Link
-            href={`/address/${address}`}
+            href={`/address/${lithoAddress}`}
             onClick={() => setWalletMenuOpen(false)}
             className="mx-auto mt-4 flex w-fit items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-xs font-medium text-white/60 transition hover:bg-white/[0.06] hover:text-white"
           >
@@ -529,7 +535,7 @@ function HeaderContent() {
             </Link>
 
             <Link
-              href={`/address/${address}`}
+              href={`/address/${lithoAddress}`}
               onClick={() => setWalletMenuOpen(false)}
               className="flex w-full items-center justify-between rounded-2xl bg-white/[0.02] px-4 py-3 text-left text-[15px] font-medium text-white/90 transition hover:bg-white/[0.06]"
             >
@@ -682,14 +688,14 @@ function HeaderContent() {
             <div className="space-y-3">
               <div className="rounded-2xl border border-white/10 bg-[#141927] px-4 py-3">
                 <div className="flex items-center justify-between text-xs">
-                  <span className="font-mono text-white/75">{shortenAddress(address)}</span>
+                  <span className="font-mono text-white/75" title={lithoAddress}>{shortenAddress(lithoAddress)}</span>
                   <span className="text-white/45">LITHO</span>
                 </div>
                 <div className="mt-1 text-sm font-semibold text-white">{balanceText}</div>
               </div>
               {address && (
                 <Link
-                  href={`/address/${address}`}
+                  href={`/address/${lithoAddress}`}
                   onClick={() => setMenuOpen(false)}
                   className="block w-full rounded-2xl border border-white/10 bg-[#141927] px-4 py-3 text-center text-sm text-white/85 transition hover:border-white/20 hover:bg-[#1b2132]"
                 >
@@ -801,8 +807,8 @@ function HeaderContent() {
                     }`}
                   />
                 )}
-                <span className="font-medium">
-                  {isConnected ? shortenAddress(address) : 'Connect Wallet'}
+                <span className="font-medium" title={isConnected ? lithoAddress : undefined}>
+                  {isConnected ? shortenAddress(lithoAddress) : 'Connect Wallet'}
                 </span>
                 {isConnected && (
                   <span className="max-w-[96px] truncate text-xs text-white/60">

--- a/Makalu/explorer/lib/format.ts
+++ b/Makalu/explorer/lib/format.ts
@@ -252,6 +252,29 @@ export function isValidatorAddress(addr: string): boolean {
   return addr.startsWith('lithovaloper1');
 }
 
+/**
+ * Preferred *display* form for an address: the Lithosphere bech32 form whenever
+ * the value can be expressed that way, otherwise the input untouched.
+ *
+ * Both formats resolve on /address/… and the API, so this is safe to use for
+ * href targets as well as label text.
+ */
+export function preferLitho(addr: string | null | undefined): string {
+  if (!addr) return '';
+  if (isBech32Address(addr)) return addr;
+  return evmToCosmos(addr) ?? addr;
+}
+
+/**
+ * Truncate an address for table/pill display. Bech32 addresses get a longer
+ * head than 0x ones because the shared `litho1` prefix carries no information —
+ * without it every litho address would render as an identical `litho1...`.
+ */
+export function truncateAddressSmart(addr: string | null | undefined, end = 6): string {
+  if (!addr) return '';
+  return truncateHash(addr, isBech32Address(addr) ? 11 : 8, end);
+}
+
 export function formatBlockTime(seconds: number | null | undefined): string {
   if (seconds == null) return '-';
   return `${seconds.toFixed(2)}s`;

--- a/Makalu/explorer/pages/address/[address].tsx
+++ b/Makalu/explorer/pages/address/[address].tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useApi } from '@/lib/api';
 import { EXPLORER_TITLE } from '@/lib/constants';
-import { formatNumber, formatSupply, truncateHash, timeAgo, formatTimestamp, formatLitho, formatValue, evmToCosmos } from '@/lib/format';
+import { formatNumber, formatSupply, truncateHash, timeAgo, formatTimestamp, formatLitho, formatValue, preferLitho, truncateAddressSmart, altAddressFormat } from '@/lib/format';
 import { getPreferredTxHash, isValidTransactionHash } from '@/lib/tx';
 import type { ApiAddress, ApiTx, ApiTokenDetail, ApiTokenHolderList, ApiPrice, ApiAddressTxList, PageInfo, ApiAddressToken, ApiAddressTokenTransferList, ApiTokenTransferList } from '@/lib/types';
 import { FormattedValueElement } from '@/components/FormattedValueElement';
@@ -533,21 +533,22 @@ function TokenTransfersTab({ addr, currentAddrs }: { addr: string; currentAddrs:
               </div>
               <div className="flex items-center min-w-0">
                 <span className="mr-2 w-16 shrink-0 text-xs text-white/40 lg:hidden">From</span>
+                {/* Membership check stays on the raw value — currentAddrSet holds both formats. */}
                 {currentAddrSet.has(t.fromAddress?.toLowerCase()) ? (
-                  <span className="block truncate font-mono text-sm text-white/40" title={t.fromAddress}>{truncateHash(t.fromAddress, 8, 6)}</span>
+                  <span className="block truncate font-mono text-sm text-white/40" title={`${preferLitho(t.fromAddress)}\n${t.fromAddress}`}>{truncateAddressSmart(preferLitho(t.fromAddress))}</span>
                 ) : (
-                  <Link href={`/address/${t.fromAddress}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={t.fromAddress}>
-                    {truncateHash(t.fromAddress, 8, 6)}
+                  <Link href={`/address/${preferLitho(t.fromAddress)}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={`${preferLitho(t.fromAddress)}\n${t.fromAddress}`}>
+                    {truncateAddressSmart(preferLitho(t.fromAddress))}
                   </Link>
                 )}
               </div>
               <div className="flex items-center min-w-0">
                 <span className="mr-2 w-16 shrink-0 text-xs text-white/40 lg:hidden">To</span>
                 {currentAddrSet.has(t.toAddress?.toLowerCase()) ? (
-                  <span className="block truncate font-mono text-sm text-white/40" title={t.toAddress}>{truncateHash(t.toAddress, 8, 6)}</span>
+                  <span className="block truncate font-mono text-sm text-white/40" title={`${preferLitho(t.toAddress)}\n${t.toAddress}`}>{truncateAddressSmart(preferLitho(t.toAddress))}</span>
                 ) : (
-                  <Link href={`/address/${t.toAddress}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={t.toAddress}>
-                    {truncateHash(t.toAddress, 8, 6)}
+                  <Link href={`/address/${preferLitho(t.toAddress)}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={`${preferLitho(t.toAddress)}\n${t.toAddress}`}>
+                    {truncateAddressSmart(preferLitho(t.toAddress))}
                   </Link>
                 )}
               </div>
@@ -1006,14 +1007,14 @@ function TokenContractTransfersTab({ addr, tokenDetail }: { addr: string; tokenD
             </div>
             <div className="flex items-center min-w-0">
               <span className="mr-2 w-16 shrink-0 text-xs text-white/40 lg:hidden">From</span>
-              <Link href={`/address/${t.fromAddress}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={t.fromAddress}>
-                {truncateHash(t.fromAddress, 8, 6)}
+              <Link href={`/address/${preferLitho(t.fromAddress)}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={`${preferLitho(t.fromAddress)}\n${t.fromAddress}`}>
+                {truncateAddressSmart(preferLitho(t.fromAddress))}
               </Link>
             </div>
             <div className="flex items-center min-w-0">
               <span className="mr-2 w-16 shrink-0 text-xs text-white/40 lg:hidden">To</span>
-              <Link href={`/address/${t.toAddress}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={t.toAddress}>
-                {truncateHash(t.toAddress, 8, 6)}
+              <Link href={`/address/${preferLitho(t.toAddress)}`} className="block truncate font-mono text-sm text-emerald-300 hover:text-emerald-200 transition" title={`${preferLitho(t.toAddress)}\n${t.toAddress}`}>
+                {truncateAddressSmart(preferLitho(t.toAddress))}
               </Link>
             </div>
             <div className="flex items-center justify-end gap-1.5 min-w-0">
@@ -1103,11 +1104,11 @@ function TokenContractLayout({
           )}
           {!isToken && (
             <h1 className="text-2xl font-semibold break-all">
-              <span className="font-mono">{account.address}</span>
+              <span className="font-mono">{preferLitho(account.address)}</span>
             </h1>
           )}
           <div className="flex items-center gap-2 shrink-0">
-            <CopyBtn text={account.address} />
+            <CopyBtn text={preferLitho(account.address)} />
             <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${
               isToken
                 ? (isNft
@@ -1121,7 +1122,7 @@ function TokenContractLayout({
         </div>
 
         {isToken && (
-          <div className="font-mono text-sm text-white/40 break-all">{account.address}</div>
+          <div className="font-mono text-sm text-white/40 break-all">{preferLitho(account.address)}</div>
         )}
       </div>
 
@@ -1156,16 +1157,17 @@ function TokenContractLayout({
         <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-4 py-4 border-b border-white/5 min-w-0">
           <div className="sm:w-40 shrink-0 text-sm text-white/45">Contract Address</div>
           <div className="flex-1 min-w-0 text-sm text-white font-mono break-all break-words">
-            {account.address}
+            {/* Litho-first: bech32 leads regardless of which format the URL used. */}
+            {preferLitho(account.address)}
             <span className="inline-block ml-2 align-middle">
-              <CopyBtn text={account.address} />
+              <CopyBtn text={preferLitho(account.address)} />
             </span>
-            {evmToCosmos(account.address) && (
+            {altAddressFormat(preferLitho(account.address)) && (
               <div className="mt-1.5 text-xs text-white/40">
-                <span className="text-white/30">Lithosphere format: </span>
-                {evmToCosmos(account.address)}
+                <span className="text-white/30">EVM format: </span>
+                {altAddressFormat(preferLitho(account.address))}
                 <span className="inline-block ml-2 align-middle">
-                  <CopyBtn text={evmToCosmos(account.address)!} />
+                  <CopyBtn text={altAddressFormat(preferLitho(account.address))!} />
                 </span>
               </div>
             )}
@@ -1262,11 +1264,10 @@ function WalletLayout({
   const resolvedTab = WALLET_TABS.some((t) => t.key === activeTab) ? activeTab : 'transactions';
   const currentAddrs = [account.address, account.evmAddress, account.cosmosAddress].filter((value): value is string => Boolean(value));
 
-  const altAddress = account.evmAddress && account.evmAddress !== account.address
-    ? account.evmAddress
-    : account.cosmosAddress && account.cosmosAddress !== account.address
-      ? account.cosmosAddress
-      : null;
+  // Litho-first: the bech32 form is always primary, so the page reads the same
+  // whether it was reached via /address/litho1… or /address/0x….
+  const primaryAddress = preferLitho(account.address);
+  const altAddress = altAddressFormat(primaryAddress) ?? null;
   const altAddressLabel = altAddress?.startsWith('0x') ? 'EVM' : 'Lithosphere';
   const balanceSource = account.balanceSource;
   const hasBalance = hasDisplayBalance(account.balance, balanceSource);
@@ -1284,10 +1285,10 @@ function WalletLayout({
 
         <div className="flex flex-col sm:flex-row sm:items-center gap-3 min-w-0">
           <h1 className="flex-1 min-w-0 text-2xl font-semibold break-all break-words">
-            <span className="font-mono">{account.address}</span>
+            <span className="font-mono">{primaryAddress}</span>
           </h1>
           <div className="flex items-center gap-2 shrink-0">
-            <CopyBtn text={account.address} />
+            <CopyBtn text={primaryAddress} />
             {account.isValidator ? (
               <span className="inline-flex items-center rounded-full border border-violet-400/30 bg-violet-400/10 px-2.5 py-0.5 text-xs font-medium text-violet-300">Validator</span>
             ) : (

--- a/Makalu/explorer/pages/nfts/index.tsx
+++ b/Makalu/explorer/pages/nfts/index.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useApi } from '@/lib/api';
 import { EXPLORER_TITLE, POLL_INTERVAL } from '@/lib/constants';
-import { formatNumber, truncateHash, timeAgo } from '@/lib/format';
+import { formatNumber, truncateHash, timeAgo, preferLitho, truncateAddressSmart } from '@/lib/format';
 import type { ApiNftCollection, ApiNftTransferList } from '@/lib/types';
 
 const AVATAR_COLORS = [
@@ -184,11 +184,12 @@ export default function NftsPage() {
                           <td className="px-4 py-4 text-sm text-white/70 text-right tabular-nums">{formatNumber(c.transfers)}</td>
                           <td className="px-4 py-4 text-sm">
                             <Link
-                              href={`/address/${c.contractAddress}`}
+                              href={`/address/${preferLitho(c.contractAddress)}`}
                               className="text-emerald-300 hover:text-emerald-200 font-mono transition"
+                              title={`${preferLitho(c.contractAddress)}\n${c.contractAddress}`}
                               onClick={(e) => e.stopPropagation()}
                             >
-                              {truncateHash(c.contractAddress)}
+                              {truncateAddressSmart(preferLitho(c.contractAddress))}
                             </Link>
                           </td>
                         </tr>
@@ -238,7 +239,7 @@ export default function NftsPage() {
                     <div className="mt-3 pt-3 border-t border-white/5">
                       <div className="text-xs text-white/30 mb-0.5">Contract</div>
                       <span className="block max-w-full truncate text-sm font-mono text-emerald-300">
-                        {truncateHash(c.contractAddress, 10, 6)}
+                        {truncateAddressSmart(preferLitho(c.contractAddress))}
                       </span>
                     </div>
                   </Link>
@@ -294,7 +295,7 @@ export default function NftsPage() {
                             href={`/token/${t.contractAddress}`}
                             className="truncate text-sm font-semibold text-white hover:text-emerald-300 transition"
                           >
-                            {t.collectionName ?? t.collectionSymbol ?? truncateHash(t.contractAddress)}
+                            {t.collectionName ?? t.collectionSymbol ?? truncateAddressSmart(preferLitho(t.contractAddress))}
                           </Link>
                           {t.tokenId != null && (
                             <span className="shrink-0 rounded-md border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-300">
@@ -312,12 +313,12 @@ export default function NftsPage() {
                         )}
                       </div>
                       <div className="flex min-w-0 items-center gap-2 text-xs text-white/60">
-                        <Link href={`/address/${t.fromAddress}`} className="truncate font-mono hover:text-white transition" title={t.fromAddress}>
-                          {truncateHash(t.fromAddress, 8, 5)}
+                        <Link href={`/address/${preferLitho(t.fromAddress)}`} className="truncate font-mono hover:text-white transition" title={`${preferLitho(t.fromAddress)}\n${t.fromAddress}`}>
+                          {truncateAddressSmart(preferLitho(t.fromAddress), 5)}
                         </Link>
                         <span className="shrink-0 text-white/30">→</span>
-                        <Link href={`/address/${t.toAddress}`} className="truncate font-mono hover:text-white transition" title={t.toAddress}>
-                          {truncateHash(t.toAddress, 8, 5)}
+                        <Link href={`/address/${preferLitho(t.toAddress)}`} className="truncate font-mono hover:text-white transition" title={`${preferLitho(t.toAddress)}\n${t.toAddress}`}>
+                          {truncateAddressSmart(preferLitho(t.toAddress), 5)}
                         </Link>
                       </div>
                       <div className="shrink-0 text-xs tabular-nums text-white/40">

--- a/Makalu/explorer/pages/token/[address].tsx
+++ b/Makalu/explorer/pages/token/[address].tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useApi } from '@/lib/api';
 import { EXPLORER_TITLE } from '@/lib/constants';
-import { formatNumber, formatSupply, truncateHash, timeAgo, formatTimestamp, formatValue, evmToCosmos } from '@/lib/format';
+import { formatNumber, formatSupply, truncateHash, timeAgo, formatTimestamp, formatValue, evmToCosmos, preferLitho, truncateAddressSmart } from '@/lib/format';
 import { isValidTransactionHash } from '@/lib/tx';
 import type {
   ApiTokenDetail,
@@ -277,22 +277,22 @@ function TransfersTab({ address, decimals, symbol, isNft }: { address: string; d
                 <div className="flex min-w-0 items-center">
                   <span className="mr-2 w-12 shrink-0 text-xs text-white/40 lg:hidden">From</span>
                   <Link
-                    href={`/address/${tx.fromAddress}`}
+                    href={`/address/${preferLitho(tx.fromAddress)}`}
                     className="block truncate font-mono text-sm text-emerald-300 transition hover:text-emerald-200"
-                    title={tx.fromAddress}
+                    title={`${preferLitho(tx.fromAddress)}\n${tx.fromAddress}`}
                   >
-                    {truncateHash(tx.fromAddress, 10, 6)}
+                    {truncateAddressSmart(preferLitho(tx.fromAddress))}
                   </Link>
                 </div>
 
                 <div className="flex min-w-0 items-center">
                   <span className="mr-2 w-12 shrink-0 text-xs text-white/40 lg:hidden">To</span>
                   <Link
-                    href={`/address/${tx.toAddress}`}
+                    href={`/address/${preferLitho(tx.toAddress)}`}
                     className="block truncate font-mono text-sm text-emerald-300 transition hover:text-emerald-200"
-                    title={tx.toAddress}
+                    title={`${preferLitho(tx.toAddress)}\n${tx.toAddress}`}
                   >
-                    {truncateHash(tx.toAddress, 10, 6)}
+                    {truncateAddressSmart(preferLitho(tx.toAddress))}
                   </Link>
                 </div>
 
@@ -703,17 +703,21 @@ function InfoTab({ token }: { token: ApiTokenDetail }) {
             <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-4 px-5 py-4">
               <div className="sm:w-44 shrink-0 text-sm text-white/45">Contract Address</div>
               <div className="flex-1 text-sm font-mono break-all">
-                <Link href={`/address/${token.contractAddress}`} className="text-emerald-300 hover:text-emerald-200 transition">
-                  {token.contractAddress}
+                {/* Litho-first: the native bech32 identity leads, EVM is the alias below. */}
+                <Link
+                  href={`/address/${preferLitho(token.contractAddress)}`}
+                  className="text-emerald-300 hover:text-emerald-200 transition"
+                >
+                  {preferLitho(token.contractAddress)}
                 </Link>
-                <CopyBtn text={token.contractAddress} />
+                <CopyBtn text={preferLitho(token.contractAddress)} />
                 {evmToCosmos(token.contractAddress) && (
                   <div className="mt-1.5 text-xs text-white/40">
-                    <span className="text-white/30">Lithosphere format: </span>
+                    <span className="text-white/30">EVM format: </span>
                     <Link href={`/address/${token.contractAddress}`} className="text-white/55 hover:text-emerald-300 transition break-all">
-                      {evmToCosmos(token.contractAddress)}
+                      {token.contractAddress}
                     </Link>
-                    <CopyBtn text={evmToCosmos(token.contractAddress)!} />
+                    <CopyBtn text={token.contractAddress} />
                   </div>
                 )}
               </div>
@@ -858,15 +862,30 @@ export default function TokenDetailPage() {
           {/* Contract address + add-to-wallet on header */}
           {token.contractAddress && (
             <div className="sm:ml-auto flex flex-wrap items-center gap-2">
-              <div className="flex items-center gap-2 bg-white/5 rounded-2xl border border-white/10 px-4 py-2">
-                <span className="text-xs text-white/40">Contract:</span>
-                <Link
-                  href={`/address/${token.contractAddress}`}
-                  className="font-mono text-sm text-emerald-300 hover:text-emerald-200 transition"
-                >
-                  {truncateHash(token.contractAddress, 10, 8)}
-                </Link>
-                <CopyBtn text={token.contractAddress} />
+              <div className="bg-white/5 rounded-2xl border border-white/10 px-4 py-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-white/40">Contract:</span>
+                  <Link
+                    href={`/address/${preferLitho(token.contractAddress)}`}
+                    className="font-mono text-sm text-emerald-300 hover:text-emerald-200 transition"
+                    title={preferLitho(token.contractAddress)}
+                  >
+                    {truncateAddressSmart(preferLitho(token.contractAddress), 8)}
+                  </Link>
+                  <CopyBtn text={preferLitho(token.contractAddress)} />
+                </div>
+                {evmToCosmos(token.contractAddress) && (
+                  <div className="mt-0.5 flex items-center gap-2 text-xs text-white/35">
+                    <span className="shrink-0">EVM:</span>
+                    <Link
+                      href={`/address/${token.contractAddress}`}
+                      className="font-mono hover:text-emerald-300 transition"
+                      title={token.contractAddress}
+                    >
+                      {truncateHash(token.contractAddress, 8, 6)}
+                    </Link>
+                  </div>
+                )}
               </div>
               {!isNative && !isNft && (
                 <AddToWalletBtn

--- a/Makalu/explorer/pages/tokens/index.tsx
+++ b/Makalu/explorer/pages/tokens/index.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useApi } from '@/lib/api';
 import { EXPLORER_TITLE } from '@/lib/constants';
-import { formatNumber, formatSupply, truncateHash } from '@/lib/format';
+import { formatNumber, formatSupply, preferLitho, truncateAddressSmart } from '@/lib/format';
 import type { ApiToken } from '@/lib/types';
 
 const AVATAR_COLORS = [
@@ -245,10 +245,11 @@ export default function TokensPage() {
                           <td className="px-4 py-4 text-sm">
                             {token.contractAddress ? (
                               <Link
-                                href={`/address/${token.contractAddress}`}
+                                href={`/address/${preferLitho(token.contractAddress)}`}
                                 className="text-emerald-300 hover:text-emerald-200 font-mono transition"
+                                title={`${preferLitho(token.contractAddress)}\n${token.contractAddress}`}
                               >
-                                {truncateHash(token.contractAddress)}
+                                {truncateAddressSmart(preferLitho(token.contractAddress))}
                               </Link>
                             ) : (
                               <span className="text-white/30">Native</span>
@@ -315,7 +316,7 @@ export default function TokensPage() {
                         <div className="mt-3 pt-3 border-t border-white/5">
                           <div className="text-xs text-white/30 mb-0.5">Contract</div>
                           <span className="block max-w-full truncate text-sm font-mono text-emerald-300">
-                            {truncateHash(token.contractAddress, 10, 6)}
+                            {truncateAddressSmart(preferLitho(token.contractAddress))}
                           </span>
                         </div>
                       )}

--- a/Makalu/explorer/test/format.test.ts
+++ b/Makalu/explorer/test/format.test.ts
@@ -15,6 +15,8 @@ import {
   evmToCosmos,
   cosmosToEvm,
   altAddressFormat,
+  preferLitho,
+  truncateAddressSmart,
   proposalStatusColor,
   timeAgo,
   truncateAddress,
@@ -43,6 +45,45 @@ describe('address format conversion (litho1 ⇄ 0x)', () => {
 
   it('is case-insensitive on the bech32 input', () => {
     expect(cosmosToEvm(LITHO.toUpperCase().replace('LITHO1', 'litho1'))).toBe(EVM);
+  });
+
+  it('preferLitho converts EVM input to bech32', () => {
+    expect(preferLitho(EVM)).toBe(LITHO);
+  });
+
+  it('preferLitho leaves an already-bech32 address untouched', () => {
+    expect(preferLitho(LITHO)).toBe(LITHO);
+  });
+
+  it('preferLitho falls back to the input when it is not convertible', () => {
+    expect(preferLitho('not-an-address')).toBe('not-an-address');
+    expect(preferLitho(null)).toBe('');
+    expect(preferLitho(undefined)).toBe('');
+  });
+
+  it('truncateAddressSmart keeps a longer head for bech32 so addresses stay distinguishable', () => {
+    const a = truncateAddressSmart(LITHO);
+    // Must retain characters beyond the shared `litho1` prefix.
+    expect(a.startsWith('litho1')).toBe(true);
+    expect(a.slice(0, 11)).toBe(LITHO.slice(0, 11));
+    expect(a.endsWith(LITHO.slice(-6))).toBe(true);
+  });
+
+  // Anchors the codec against a pair confirmed live by GET /api/address/… on
+  // Makalu (the FGPT LEP-100 contract), not just internal round-tripping.
+  it('matches the bech32 form the Makalu API returns for a known contract', () => {
+    expect(preferLitho('0x151ef362ea96853702cc5e7728107e3961fbd22e'))
+      .toBe('litho1z500xch2j6znwqkvtemjsyr789slh53wstcpq4');
+  });
+
+  it('truncateAddressSmart distinguishes two addresses sharing the litho1 prefix', () => {
+    const other = evmToCosmos('0x151ef362ea96853702cc5e7728107e3961fbd22e')!;
+    expect(truncateAddressSmart(other)).not.toBe(truncateAddressSmart(LITHO));
+  });
+
+  it('truncateAddressSmart handles empty input', () => {
+    expect(truncateAddressSmart('')).toBe('');
+    expect(truncateAddressSmart(null)).toBe('');
   });
 
   it('altAddressFormat returns the opposite encoding', () => {


### PR DESCRIPTION
Surfaces the native `litho1…` identity as the primary address across the explorer, with the `0x` form kept as a secondary alias rather than dropped.

## Helpers

Two additions in `lib/format.ts`:

- `preferLitho()` — bech32 when convertible, input untouched otherwise
- `truncateAddressSmart()` — longer head for bech32, since every address shares the `litho1` prefix and would otherwise truncate to an identical label

## Surfaces changed

- **Header** — wallet pill (desktop + mobile) and the wallet overlay; the copy button, Block Explorer and **Activity** links now target the bech32 form
- **Token detail** — contract chip and Contract Address row lead with litho, labelling the `0x` value `EVM format`; transfers From/To render bech32
- **`/tokens`, `/nfts`** — contract columns and mobile cards
- **`/address/[address]`** — transfer tables, plus the header

## Notable

On the address page the primary address is now derived once via `preferLitho`, so the page reads the same whether reached via `/address/litho1…` or `/address/0x…`. The alias line moves to `altAddressFormat()` — the previous `evmToCosmos()` call returned `undefined` on a bech32 URL and **silently hid the EVM address entirely**.

Both formats already resolve on `/address/…`, `/token/…` and the API (verified live), so link targets switch safely and existing `0x` URLs keep working.

Deliberately left alone:
- The **transactions** tables were already bech32 — the API returns litho in `fromAddr`/`toAddr`.
- Membership checks against `currentAddrSet` stay on the raw value, which holds both encodings; converting the check input would look harmless but break the "this is the address you're viewing" highlight.

## Verification

- **97 tests pass** (11 new), including one anchoring the codec to a pair confirmed live via `GET /api/address/…` rather than internal round-tripping alone — round-trip tests would pass even with a wrong HRP or checksum.
- `tsc --noEmit`: 7 pre-existing errors in `build-info.test.ts`, none in touched files.
- `next lint`: parity against stashed baseline (25/25, then 18/18). Zero introduced.
- `next build`: compiles, 22/22 static pages.

## Caveat

Verified by build, typecheck and tests — **not rendered in a browser**. The two-line contract chip and the wider bech32 strings in narrow table columns are the most likely spots to want a visual tweak.