### PR TITLE
fix(ci): make required status checks reportable on every PR

### DIFF
--- a/.github/workflows/ci-abi-gate.yaml
+++ b/.github/workflows/ci-abi-gate.yaml
@@ -1,0 +1,135 @@
+# Lithosphere CI — ABI Drift Gate
+#
+# This workflow exists to host a single job: "ABI Sync Check", which is a
+# REQUIRED status check on main.
+#
+# Why it lives here instead of ci-contracts.yaml:
+#   ci-contracts.yaml is path-filtered to Makalu/contracts/**, so on a PR that
+#   touches nothing under contracts the workflow never runs and the required
+#   "ABI Sync Check" context is never reported. Branch protection then blocks
+#   the PR forever, no matter how many approvals it has — the only way through
+#   is an admin override. That affected every non-contract PR in the repo.
+#
+# Why not a complementary paths-ignore "skip" workflow:
+#   GitHub runs a paths-ignore workflow when ANY changed file falls outside the
+#   ignore list, so a PR touching both contracts/ and explorer/ would trigger
+#   the real check AND the no-op, producing two check runs with the same name.
+#   A trivial success could then mask genuine ABI drift.
+#
+# The approach here: this workflow always runs, and decides internally whether
+# the drift check is applicable. Exactly one "ABI Sync Check" run is reported
+# per commit — a real one when contracts changed, a trivial pass otherwise.
+#
+# Keep the job name in sync with the required status check configured in
+# branch protection for main.
+
+name: CI ABI Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Opt every JavaScript-based action into Node.js 24 ahead of the
+  # runner-wide default flip.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  abi-sync-check:
+    name: ABI Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ./Makalu/contracts
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the PR base commit is available to diff against.
+          fetch-depth: 0
+
+      # On a PR, the drift check only means something if contract sources (or
+      # this gate) changed. On a push to main we always run it — the protected
+      # branch is worth the extra few minutes.
+      - name: Detect contract changes
+        id: changes
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Push to main — running the drift check unconditionally."
+            echo "applicable=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # base.sha comes straight from the event payload; checkout above used
+          # fetch-depth: 0, so it is present locally. Fall back to the remote
+          # branch ref if it somehow isn't.
+          base="${{ github.event.pull_request.base.sha }}"
+          if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${{ github.base_ref }}" >/dev/null 2>&1 || true
+            base="origin/${{ github.base_ref }}"
+          fi
+
+          changed=$(git diff --name-only "$base...HEAD")
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          if echo "$changed" | grep -qE '^(Makalu/contracts/|Makalu/templates/contracts-template/|\.github/workflows/ci-abi-gate\.yaml$)'; then
+            echo "applicable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "applicable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Not applicable
+        if: steps.changes.outputs.applicable != 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "No contract sources changed in this ${{ github.event_name }}."
+          echo "ABI drift cannot occur, so this gate passes without compiling."
+
+      - uses: pnpm/action-setup@v2
+        if: steps.changes.outputs.applicable == 'true'
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        if: steps.changes.outputs.applicable == 'true'
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: Makalu/pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: steps.changes.outputs.applicable == 'true'
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: Compile
+        if: steps.changes.outputs.applicable == 'true'
+        run: pnpm compile
+
+      - name: Sync ABIs from artifacts to SDK
+        if: steps.changes.outputs.applicable == 'true'
+        run: pnpm run sync-abis
+
+      - name: Verify no drift
+        if: steps.changes.outputs.applicable == 'true'
+        run: |
+          # Print any drift before failing so the log shows what changed.
+          if ! git diff --exit-code -- ../packages/blockchain-core/src/abis/; then
+            echo ""
+            echo "::error::ABI drift detected: @lithosphere/blockchain-core ships ABIs that don't match the compiled Solidity sources."
+            echo ""
+            echo "To fix:"
+            echo "  cd Makalu/contracts"
+            echo "  pnpm run sync-abis"
+            echo "  git add ../packages/blockchain-core/src/abis/"
+            echo "  git commit -m 'chore(sdk): re-sync ABIs from contracts'"
+            exit 1
+          fi
+          echo "ABIs in sync."

--- a/.github/workflows/ci-contracts.yaml
+++ b/.github/workflows/ci-contracts.yaml
@@ -553,53 +553,12 @@ jobs:
           retention-days: 90
 
   # ─────────────────────────────────────────────────────────────────────
-  # ABI Drift Gate — fail if the SDK's vendored ABIs don't match the
-  # freshly compiled contract artifacts. Prevents shipping an
-  # @lithosphere/blockchain-core release that's out of sync with the
-  # Solidity source. Fix-it instructions are in the failure log.
+  # ABI Drift Gate — moved to .github/workflows/ci-abi-gate.yaml
+  #
+  # "ABI Sync Check" is a required status check on main. Hosting it here made
+  # it unreportable on PRs that don't touch Makalu/contracts/**, because this
+  # workflow is path-filtered — which left every non-contract PR permanently
+  # blocked. It now lives in an always-running workflow that decides internally
+  # whether the check applies. Do not re-add it here: two workflows emitting
+  # the same check name can mask a real failure.
   # ─────────────────────────────────────────────────────────────────────
-  abi-sync-check:
-    name: ABI Sync Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: compile
-    defaults:
-      run:
-        working-directory: ./Makalu/contracts
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: Makalu/pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile || pnpm install
-
-      - name: Compile
-        run: pnpm compile
-
-      - name: Sync ABIs from artifacts to SDK
-        run: pnpm run sync-abis
-
-      - name: Verify no drift
-        run: |
-          # Print any drift before failing so the log shows what changed.
-          if ! git diff --exit-code -- ../packages/blockchain-core/src/abis/; then
-            echo ""
-            echo "::error::ABI drift detected: @lithosphere/blockchain-core ships ABIs that don't match the compiled Solidity sources."
-            echo ""
-            echo "To fix:"
-            echo "  cd Makalu/contracts"
-            echo "  pnpm run sync-abis"
-            echo "  git add ../packages/blockchain-core/src/abis/"
-            echo "  git commit -m 'chore(sdk): re-sync ABIs from contracts'"
-            exit 1
-          fi
-          echo "ABIs in sync."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,18 +4,30 @@
 name: CI
 
 on:
+  # Pushes to main stay path-filtered: it's a pure optimization and does not
+  # affect merge gating.
   push:
     branches:
       - main
     paths:
       - 'Makalu/**'
       - '.github/workflows/ci.yaml'
+
+  # Pull requests are deliberately NOT path-filtered. Six of this workflow's
+  # jobs — Test, Typecheck, License Check, Schema Sync Check, OpenAPI Sync
+  # Check and OpenAPI SDK Codegen Check — are required status checks on main.
+  # A filtered trigger meant a docs-only or .github-only PR never ran them, so
+  # those contexts were never reported and branch protection blocked the PR
+  # permanently, with an admin override as the only way through.
+  #
+  # The cost is that a docs-only PR now runs the full Makalu quality gate.
+  # That's deliberate: correctness of the merge gate over a few CI minutes.
+  # If this becomes a bottleneck, the fix is change detection with jobs that
+  # still always report their check name (see ci-abi-gate.yaml) — NOT
+  # re-adding a paths filter here.
   pull_request:
     branches:
       - main
-    paths:
-      - 'Makalu/**'
-      - '.github/workflows/ci.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## The bug

Branch protection on `main` requires **`ABI Sync Check`**, but that job lived in `ci-contracts.yaml`, which is path-filtered to `Makalu/contracts/**`. On a PR touching nothing under contracts the workflow never runs, the required context is never reported, and the PR stays `BLOCKED` **regardless of approvals**. An admin override was the only way through — that's how #60 landed.

The same trap applies more broadly. Six required checks come from `ci.yaml`, filtered to `Makalu/**`:

| required check | provider | filter |
|---|---|---|
| `ABI Sync Check` | `ci-contracts.yaml` | `Makalu/contracts/**` |
| `Test`, `Typecheck`, `License Check`, `Schema Sync Check`, `OpenAPI Sync Check`, `OpenAPI SDK Codegen Check` | `ci.yaml` | `Makalu/**` |

So a **docs-only or `.github`-only PR was missing all six** and could never merge normally.

## The fix

**`ABI Sync Check` → new `ci-abi-gate.yaml`**, which always runs and decides internally whether the check applies: real compile-and-compare when contract sources changed, trivial pass otherwise, unconditional on pushes to `main`.

This was clean because the job is self-contained — it did its own checkout, install and `pnpm compile`, and **never consumed the `compile` job's artifacts**. `needs: compile` was ordering only, so dropping it changes no behaviour.

**Deliberately not a `paths-ignore` skip workflow.** GitHub runs such a workflow when *any* changed file falls outside the ignore list, so a PR touching both `contracts/` and `explorer/` would emit **two check runs with the same name** — and a trivial success could mask genuine ABI drift. Exactly one workflow now emits `ABI Sync Check`, and `ci-contracts.yaml` carries a comment warning against re-adding it.

**`ci.yaml`**: the `pull_request` trigger drops its paths filter. Its six required jobs are interdependent (`test`/`typecheck` need `build`), so per-step gating would be invasive and easy to get wrong. Required checks are only evaluated on PRs, so pushes to `main` stay filtered.

Tradeoff, stated plainly: **a docs-only PR now runs the full Makalu quality gate.** That's deliberate — correctness of the merge gate over a few CI minutes. If it becomes a bottleneck the answer is change detection with jobs that still always report, not re-adding a filter.

## Verification

- All three workflows parse as YAML; exactly one defines `name: ABI Sync Check`.
- The detection script parses under `bash -n`.
- Path classification tested against contracts, contracts-template, explorer, docs, `.github`, and the `Makalu/contracts-legacy/` near-miss (correctly skips — the original glob was `Makalu/contracts/**`).
- **Mixed `contracts/` + `explorer/` PR correctly runs the real check**, so drift stays caught.

**This PR is its own test case:** it touches only `.github/workflows/**`. If `ABI Sync Check` reports green here without an admin override, the deadlock is fixed.