### PR TITLE
fix(ci): rename duplicate Test check in ci-contracts

### DIFF
--- a/.github/workflows/ci-contracts.yaml
+++ b/.github/workflows/ci-contracts.yaml
@@ -68,9 +68,15 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────
   # Run contract tests (Makalu/contracts + contracts-template)
+  #
+  # Named "Contract Tests", not "Test": ci.yaml also has a job named "Test",
+  # which is a REQUIRED status check on main. Two workflows emitting the same
+  # check name makes it ambiguous which run branch protection honours, so a
+  # failure in one could be masked by a pass in the other. Keep this name
+  # distinct from every job name in ci.yaml.
   # ─────────────────────────────────────────────────────────────────────
   test:
-    name: Test
+    name: Contract Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: compile


### PR DESCRIPTION
Follow-up to #61.

## Problem

`ci.yaml` and `ci-contracts.yaml` both defined a job named **`Test`**, and `Test` is a **required** status check on `main`. Two workflows emitting the same check name leaves it ambiguous which run branch protection honours — a failure in one could be masked by a pass in the other. This is the same hazard the ABI gate in #61 was designed to avoid.

## Change

The contracts job is renamed to **`Contract Tests`**. Only the display name changes — the job id stays `test`, and nothing uses `needs: test`.

`ci.yaml`'s `Test` continues to satisfy the required context, and since e403b4f its `pull_request` trigger is unfiltered, so it reports on every PR.

## Deliberate: `Contract Tests` is not added to the required contexts

`ci-contracts.yaml` is path-filtered to `Makalu/contracts/**`, so requiring the renamed check would **recreate exactly the deadlock fixed in #61** — non-contract PRs would never report it and would be blocked forever.

This matches every other job in that workflow (`Compile`, `Coverage`, `Slither`, `Foundry Fuzz`), none of which are required.

**Worth stating plainly:** contract test failures now definitively do *not* block merges. Previously that enforcement was ambiguous rather than reliable — it depended on undefined same-name tie-breaking — so this trades an unpredictable gate for a predictable non-gate. If you want contract tests to genuinely block, the correct route is the #61 pattern: an always-running job that decides internally whether to do real work, then add *that* to the required contexts.

## Verification

- YAML parses; all nine job names in `ci-contracts.yaml` are now distinct.
- Cross-workflow duplicate scan over `ci.yaml`, `ci-contracts.yaml` and `ci-abi-gate.yaml`: `Test` no longer collides.
- `Lint` is still duplicated across `ci.yaml` and `ci-contracts.yaml`, but it is **not** a required check, so it is cosmetic only — left out of this PR to keep it focused.