### PR TITLE
fix(ci): rename duplicate Lint check in ci-contracts

### DIFF
--- a/.github/workflows/ci-contracts.yaml
+++ b/.github/workflows/ci-contracts.yaml
@@ -122,9 +122,16 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────
   # Solidity linting with solhint
+  #
+  # Named "Contract Lint", not "Lint": ci.yaml also has a job named "Lint".
+  # Unlike "Test" this one is not a required status check, so the collision was
+  # cosmetic rather than a merge-gating hazard — but same-name checks across
+  # workflows are confusing in the PR checks list and become dangerous the
+  # moment the name is added to branch protection. Keep this name distinct
+  # from every job name in ci.yaml.
   # ─────────────────────────────────────────────────────────────────────
   lint:
-    name: Lint
+    name: Contract Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Follow-up to #62, completing the check-name cleanup.

## Change

`ci.yaml` and `ci-contracts.yaml` both defined a job named **`Lint`**. The contracts job becomes **`Contract Lint`**, pairing with `Contract Tests` from #62.

Only the display name changes — the job id stays `lint`, and nothing uses `needs: lint`.

## Why this one is lower stakes than #62

Unlike `Test`, **`Lint` is not a required status check**, so the collision was cosmetic rather than a merge-gating hazard. It made the PR checks list ambiguous to read, and would have become genuinely dangerous the moment someone added the name to branch protection — at which point two workflows emitting it would make enforcement undefined.

## Result

No job name is now shared across `ci.yaml`, `ci-contracts.yaml` and `ci-abi-gate.yaml`. Verified by parsing all three and cross-checking every job name:

```
duplicate check names: NONE
```

`ci-contracts.yaml` job names are now: `Compile`, `Contract Tests`, `Contract Lint`, `Gas Report`, `Coverage`, `Slither Analysis`, `Slither Analysis (production contracts)`, `Foundry Fuzz (production contracts)`, `Contract Artifacts (ABI + bytecode)`.