### PR TITLE
fix(api): resolve bech32 contract addresses on /tokens routes

### DIFF
--- a/Makalu/api/src/__tests__/routes-helpers.test.ts
+++ b/Makalu/api/src/__tests__/routes-helpers.test.ts
@@ -12,6 +12,7 @@ import {
   hasPositiveNumericString,
   hexTimestampToIso,
   hexToDec,
+  normalizeContractAddress,
   normalizeFaucetAmountInput,
   parseHexInteger,
   parseIntSafe,
@@ -354,5 +355,41 @@ describe('preferString', () => {
   it('returns the fallback unchanged when both are nullish', () => {
     expect(preferString(null, null)).toBeNull();
     expect(preferString(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('normalizeContractAddress', () => {
+  // The FGPT LEP-100 contract on Makalu — the pair that exposed the bug:
+  // /tokens/litho1… returned "Token contract not found" while /tokens/0x…
+  // returned 230 holders and 304 transfers for the same contract.
+  const EVM = '0x151ef362ea96853702cc5e7728107e3961fbd22e';
+  const LITHO = 'litho1z500xch2j6znwqkvtemjsyr789slh53wstcpq4';
+
+  it('converts a bech32 contract address to the stored EVM form', () => {
+    expect(normalizeContractAddress(LITHO)).toBe(EVM);
+  });
+
+  it('is case-insensitive on the bech32 input', () => {
+    expect(normalizeContractAddress(LITHO.toUpperCase().replace('LITHO1', 'litho1'))).toBe(EVM);
+  });
+
+  it('passes an EVM address through untouched', () => {
+    expect(normalizeContractAddress(EVM)).toBe(EVM);
+  });
+
+  it('preserves the `native` sentinel', () => {
+    expect(normalizeContractAddress('native')).toBe('native');
+  });
+
+  it('passes through undecodable input rather than throwing', () => {
+    expect(normalizeContractAddress('litho1notavalidbech32')).toBe('litho1notavalidbech32');
+    expect(normalizeContractAddress('')).toBe('');
+    expect(normalizeContractAddress('not-an-address')).toBe('not-an-address');
+  });
+
+  it('does not touch a validator address that merely starts with litho', () => {
+    // lithovaloper1… does not begin with the litho1 prefix, so it passes through.
+    const val = 'lithovaloper1abcdef';
+    expect(normalizeContractAddress(val)).toBe(val);
   });
 });

--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -394,6 +394,22 @@ export function cosmosToEvm(cosmosAddr: string | null | undefined): string | und
   }
 }
 
+/**
+ * Normalize a contract-address route param to the form stored in the DB.
+ *
+ * `contracts.address` holds EVM 0x values, but the explorer links to contracts
+ * by their Lithosphere bech32 identity, so /tokens/litho1… must resolve to the
+ * same record as /tokens/0x…. Without this, those routes returned "Token
+ * contract not found" and empty transfers/holders for a perfectly valid token.
+ *
+ * Anything that isn't a decodable litho1 address is passed through untouched,
+ * which keeps the `native` sentinel and existing 0x callers working.
+ */
+export function normalizeContractAddress(address: string): string {
+  if (!address || !address.toLowerCase().startsWith('litho1')) return address;
+  return cosmosToEvm(address) ?? address;
+}
+
 interface AddressForms {
   query: string;
   queryLower: string;
@@ -2344,7 +2360,9 @@ export function explorerRouter(): Router {
 
   r.get('/tokens/:address', async (req: Request, res: Response) => {
     try {
-      const { address } = req.params;
+      // Accept the Lithosphere bech32 form as well as 0x — the explorer links
+      // contracts by their litho1 identity.
+      const address = normalizeContractAddress(req.params.address);
 
       // Native LITHO token
       if (address === 'native') {
@@ -2453,7 +2471,7 @@ export function explorerRouter(): Router {
 
   r.get('/tokens/:address/roles', async (req: Request, res: Response) => {
     try {
-      const { address } = req.params;
+      const address = normalizeContractAddress(req.params.address);
       if (isHiddenToken({ address })) {
         res.status(404).json({ message: 'Token contract not found' });
         return;
@@ -2513,7 +2531,7 @@ export function explorerRouter(): Router {
 
   r.get('/tokens/:address/transfers', async (req: Request, res: Response) => {
     try {
-      const { address } = req.params;
+      const address = normalizeContractAddress(req.params.address);
       const limit = clamp(req.query.limit, 25);
       const offset = resolveOffset(req.query, limit);
       if (isHiddenToken({ address })) {
@@ -2612,7 +2630,7 @@ export function explorerRouter(): Router {
 
   r.get('/tokens/:address/holders', async (req: Request, res: Response) => {
     try {
-      const { address } = req.params;
+      const address = normalizeContractAddress(req.params.address);
       const limit = clamp(req.query.limit, 25);
       const offset = resolveOffset(req.query, limit);
       if (isHiddenToken({ address })) {


### PR DESCRIPTION
## The bug

Found by driving the deployed explorer in a real browser — build, typecheck and 97 tests all passed over it.

`/tokens/:address` and its sub-routes query `contracts.address` (which stores EVM `0x` values) using the raw route param. So:

```
/api/tokens/0x151ef362…/transfers  → 304 transfers
/api/tokens/litho1z500…/transfers  → []
/api/tokens/litho1z500…            → "Token contract not found"
```

Same contract, two encodings, completely different answers.

## Why it became user-visible

This is a regression from #60, which repointed contract links at bech32 URLs. `/address/litho1z500…` for a token contract now renders **`Holders: --`, `Transfers: 0`, "No transfers found"** for a token that actually has **230 holders and 304 transfers**.

The broken path existed before — nothing linked to it. #60 made it reachable from `/tokens` and the token page chip, so users clicking a contract address land on a page that silently understates the data. Misleading rather than merely cosmetic, which is why this is worth fixing at the API rather than by retreating the links to `0x`.

## The fix

`normalizeContractAddress()`, applied at the entry point of `/tokens/:address` and its `/roles`, `/transfers` and `/holders` sub-routes. It mirrors what `/address/:address` already does via `resolveAddressForms`, making bech32 first-class across both route families rather than a special case in one.

Deliberately conservative:
- Non-`litho1` input passes through untouched → the `native` sentinel and every existing `0x` caller are unaffected.
- Undecodable `litho1` strings pass through rather than throwing.
- `lithovaloper1…` doesn't match the `litho1` prefix, so validator addresses are untouched.

## Verification

- **147 tests pass** (6 new). One asserts the exact FGPT contract pair that exposed the bug — `litho1z500xch2j6znwqkvtemjsyr789slh53wstcpq4` → `0x151ef362…` — rather than a synthetic round-trip.
- Also covered: `native` sentinel preserved, case-insensitive bech32, undecodable input, `lithovaloper1` passthrough.
- `tsc --noEmit` clean.
- **OpenAPI route set still in sync at 34 endpoints** — no route surface change.

## Not included

The Token Info Card on the token detail page still renders the raw `0x` contract address (a third call site I missed in #60). That's a separate frontend change — cosmetic, no data impact.

Post-merge this needs a browser re-check against production to confirm the address page populates.