### PR TITLE
fix(explorer): Litho-first contract address in token info cards

### DIFF
--- a/Makalu/explorer/pages/token/[address].tsx
+++ b/Makalu/explorer/pages/token/[address].tsx
@@ -533,8 +533,15 @@ function ContractTab({ token }: { token: ApiTokenDetail }) {
           <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-4 px-5 py-4">
             <div className="sm:w-44 shrink-0 text-sm text-white/45">Contract Address</div>
             <div className="flex-1 text-sm text-white font-mono break-all">
-              {token.contractAddress ?? token.address}
-              <CopyBtn text={token.contractAddress ?? token.address} />
+              {preferLitho(token.contractAddress ?? token.address)}
+              <CopyBtn text={preferLitho(token.contractAddress ?? token.address)} />
+              {evmToCosmos(token.contractAddress ?? token.address) && (
+                <div className="mt-1.5 text-xs text-white/40">
+                  <span className="text-white/30">EVM format: </span>
+                  {token.contractAddress ?? token.address}
+                  <CopyBtn text={token.contractAddress ?? token.address} />
+                </div>
+              )}
             </div>
           </div>
 
@@ -934,10 +941,23 @@ export default function TokenDetailPage() {
             <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-4 py-4 border-b border-white/5">
               <div className="sm:w-44 shrink-0 text-sm text-white/45">Contract</div>
               <div className="flex-1 text-sm font-mono break-all">
-                <Link href={`/address/${token.contractAddress}`} className="text-emerald-300 hover:text-emerald-200 transition">
-                  {token.contractAddress}
+                {/* Litho-first, matching the Contract Address row in the Info tab. */}
+                <Link
+                  href={`/address/${preferLitho(token.contractAddress)}`}
+                  className="text-emerald-300 hover:text-emerald-200 transition"
+                >
+                  {preferLitho(token.contractAddress)}
                 </Link>
-                <CopyBtn text={token.contractAddress} />
+                <CopyBtn text={preferLitho(token.contractAddress)} />
+                {evmToCosmos(token.contractAddress) && (
+                  <div className="mt-1.5 text-xs text-white/40">
+                    <span className="text-white/30">EVM format: </span>
+                    <Link href={`/address/${token.contractAddress}`} className="text-white/55 hover:text-emerald-300 transition break-all">
+                      {token.contractAddress}
+                    </Link>
+                    <CopyBtn text={token.contractAddress} />
+                  </div>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
Closes the last inconsistency in the Litho-first work started in #60.

## What was wrong

Two call sites on the token detail page still rendered the raw `0x` contract address:

- **Token Info Card** → `Contract` row (visible mid-page)
- **Contract tab** → `Contract Overview` → `Contract Address` row

Both were missed in #60, which updated the header chip, the Info tab row and the transfer tables but not these. Found by driving the deployed page in a browser — build, typecheck and 97 tests all passed straight over them.

## Change

Both now lead with the bech32 form and label the `0x` value `EVM format:`, matching the pattern already used by the Info tab and the header chip.

## Deliberately untouched

- **`AddToWalletBtn`** still receives the raw `0x` address — `wallet_watchAsset` requires the EVM form. Converting it would have looked consistent and broken "Add to Wallet".
- **`RolesSection`** keeps passing `0x` to `/tokens/:address/roles`. Either form resolves since #64, but there's no reason to churn it.

## Verification

- 97 tests pass; `next build` compiles.
- Grepped every remaining `{token.contractAddress}` render to confirm each one now sits under an `EVM format:` label or is one of the two intentional exceptions above.

Purely presentational — no data flow changes. Will browser-verify against production once deployed, same as #64.