### PR TITLE
fix(explorer): route Add to Wallet through the connected wallet; fit the header pill

### DIFF
--- a/Makalu/explorer/components/Header.tsx
+++ b/Makalu/explorer/components/Header.tsx
@@ -783,12 +783,12 @@ function HeaderContent() {
 
           {/* Search + Wallet + Mobile menu */}
           <div className="flex min-w-0 items-center gap-2">
-            <div className="hidden md:block">
+            <div className="hidden min-w-0 shrink md:block">
               <SearchBar />
             </div>
 
             {/* Wallet button + menu */}
-            <div className="hidden sm:block">
+            <div className="hidden min-w-0 sm:block">
               <button
                 type="button"
                 onClick={() => {
@@ -798,20 +798,23 @@ function HeaderContent() {
                   }
                   setWalletMenuOpen((prev) => !prev);
                 }}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/30 px-3 py-2 text-sm text-white transition hover:border-white/20 hover:bg-black/40"
+                className="inline-flex min-w-0 max-w-[15rem] items-center gap-2 rounded-full border border-white/10 bg-black/30 px-3 py-2 text-sm text-white transition hover:border-white/20 hover:bg-black/40"
               >
                 {isConnected && (
                   <span
-                    className={`h-2 w-2 rounded-full ${
+                    className={`h-2 w-2 shrink-0 rounded-full ${
                       isOnMakalu ? 'bg-emerald-300' : 'bg-amber-300'
                     }`}
                   />
                 )}
-                <span className="font-medium" title={isConnected ? lithoAddress : undefined}>
+                <span className="min-w-0 truncate font-medium" title={isConnected ? lithoAddress : undefined}>
                   {isConnected ? shortenAddress(lithoAddress) : 'Connect Wallet'}
                 </span>
+                {/* bech32 labels are wider than 0x ones, so the balance only
+                    rides along once there is room for it. It is always visible
+                    in the wallet menu. */}
                 {isConnected && (
-                  <span className="max-w-[96px] truncate text-xs text-white/60">
+                  <span className="hidden max-w-[96px] shrink-0 truncate text-xs text-white/60 xl:inline">
                     {balanceText}
                   </span>
                 )}

--- a/Makalu/explorer/components/SearchBar.tsx
+++ b/Makalu/explorer/components/SearchBar.tsx
@@ -61,7 +61,7 @@ export default function SearchBar() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search by block, tx, address, or name.litho..."
-          className="w-full sm:w-64 lg:w-72 xl:w-80 px-4 py-2 pr-10 text-sm rounded-lg
+          className="w-full sm:w-56 lg:w-64 xl:w-72 min-w-0 px-4 py-2 pr-10 text-sm rounded-lg
             bg-[var(--color-bg-primary)] border border-[var(--color-border)]
             text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)]
             focus:outline-none focus:border-litho-400 focus:ring-1 focus:ring-litho-400

--- a/Makalu/explorer/pages/token/[address].tsx
+++ b/Makalu/explorer/pages/token/[address].tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
+import { useWeb3ModalProvider } from '@web3modal/ethers/react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -111,11 +112,19 @@ function AddToWalletBtn({
   image?: string;
 }) {
   const [status, setStatus] = useState<'idle' | 'adding' | 'added' | 'unavailable' | 'rejected'>('idle');
+  const { walletProvider } = useWeb3ModalProvider();
 
   const handleAdd = useCallback(async () => {
-    const eth = (typeof window !== 'undefined'
+    // Prefer the wallet the user actually connected. `window.ethereum` is the
+    // legacy single-injection slot, which MetaMask claims when installed — so
+    // reading it directly sent every request to MetaMask and made EIP-6963
+    // wallets like Thanos (rdns fi.thanos.wallet) look undetected even while
+    // connected. Fall back to window.ethereum only when nothing is connected.
+    const connected = walletProvider as unknown as WatchAssetProvider | undefined;
+    const injected = (typeof window !== 'undefined'
       ? (window as unknown as { ethereum?: WatchAssetProvider }).ethereum
       : undefined);
+    const eth = connected?.request ? connected : injected;
     if (!eth?.request) {
       setStatus('unavailable');
       setTimeout(() => setStatus('idle'), 2500);
@@ -142,7 +151,7 @@ function AddToWalletBtn({
     } finally {
       setTimeout(() => setStatus('idle'), 2500);
     }
-  }, [address, symbol, decimals, image]);
+  }, [address, symbol, decimals, image, walletProvider]);
 
   const label =
     status === 'adding' ? 'Adding…' :


### PR DESCRIPTION
Two issues from feedback on the deployed site.

## 1. "Add to Wallet" didn't detect Thanos (but did detect MetaMask)

`AddToWalletBtn` read **`window.ethereum`** directly. That's the legacy single-injection slot, which **MetaMask claims when installed** — so every `wallet_watchAsset` call went to MetaMask, and EIP-6963 wallets like Thanos (`rdns fi.thanos.wallet`) appeared undetected *even while connected*.

It now prefers the provider from `useWeb3ModalProvider()` — the wallet the user actually connected — falling back to `window.ethereum` only when nothing is connected.

`AddToWalletBtn` still receives the raw `0x` address; `wallet_watchAsset` requires the EVM form.

## 2. Header pill overflowed once it showed a bech32 address

`litho1…` labels are wider than `0x…` ones, and neither the pill nor the fixed-width search input could shrink — so the pill clipped at the viewport edge.

- pill: `min-w-0` + `max-w-[15rem]`, address truncates, status dot `shrink-0`
- balance moves to `xl:` and up, where there's room. **It's always visible in the wallet menu**, so nothing is lost on smaller screens.
- search input: `sm:w-64/lg:w-72/xl:w-80` → `sm:w-56/lg:w-64/xl:w-72`, plus `min-w-0` so it yields space instead of forcing overflow

## Verification

97 tests pass; `tsc` clean (the 7 pre-existing `build-info.test.ts` errors unchanged); `next build` compiles.

**Both fixes are wallet-connected states I cannot reproduce headlessly** — no browser verification. Needs a check with Thanos connected: that "Add to Wallet" now prompts Thanos rather than MetaMask, and that the pill fits.