### PR TITLE
fix: show token holders in litho format; name unindexed tokens on tx pages

### DIFF
--- a/Makalu/api/src/__tests__/routes-helpers.test.ts
+++ b/Makalu/api/src/__tests__/routes-helpers.test.ts
@@ -12,6 +12,7 @@ import {
   hasPositiveNumericString,
   hexTimestampToIso,
   hexToDec,
+  decodeAbiString,
   normalizeContractAddress,
   normalizeFaucetAmountInput,
   parseHexInteger,
@@ -391,5 +392,48 @@ describe('normalizeContractAddress', () => {
     // lithovaloper1… does not begin with the litho1 prefix, so it passes through.
     const val = 'lithovaloper1abcdef';
     expect(normalizeContractAddress(val)).toBe(val);
+  });
+});
+
+describe('decodeAbiString', () => {
+  // ABI dynamic string: 0x + [offset 32B][length 32B][utf8 bytes padded to 32B].
+  // "FGPT" = 4 bytes -> length 0x04, then 46475054 padded.
+  const FGPT = '0x' +
+    '0000000000000000000000000000000000000000000000000000000000000020' +
+    '0000000000000000000000000000000000000000000000000000000000000004' +
+    '4647505400000000000000000000000000000000000000000000000000000000';
+
+  it('decodes a standard ABI-encoded token symbol', () => {
+    expect(decodeAbiString(FGPT)).toBe('FGPT');
+  });
+
+  it('trims trailing NUL padding and whitespace', () => {
+    const padded = '0x' +
+      '0000000000000000000000000000000000000000000000000000000000000020' +
+      '0000000000000000000000000000000000000000000000000000000000000006' +
+      '467572475054000000000000000000000000000000000000000000000000000000'.slice(0, 64);
+    expect(decodeAbiString(padded)).toBe('FurGPT');
+  });
+
+  it('returns null for empty / 0x / non-string input', () => {
+    expect(decodeAbiString('0x')).toBeNull();
+    expect(decodeAbiString('')).toBeNull();
+    expect(decodeAbiString(null)).toBeNull();
+    expect(decodeAbiString(undefined)).toBeNull();
+    expect(decodeAbiString(42)).toBeNull();
+  });
+
+  it('returns null for an all-zero (empty string) result', () => {
+    const empty = '0x' +
+      '0000000000000000000000000000000000000000000000000000000000000020' +
+      '0000000000000000000000000000000000000000000000000000000000000000';
+    expect(decodeAbiString(empty)).toBeNull();
+  });
+
+  it('rejects an implausibly long length claim', () => {
+    const huge = '0x' +
+      '0000000000000000000000000000000000000000000000000000000000000020' +
+      '0000000000000000000000000000000000000000000000000000000000000fff';
+    expect(decodeAbiString(huge)).toBeNull();
   });
 });

--- a/Makalu/api/src/routes.ts
+++ b/Makalu/api/src/routes.ts
@@ -855,6 +855,46 @@ async function fetchLiveBalance(addr: string): Promise<string | null> {
   return null;
 }
 
+/** Decode the ABI-encoded string returned by an ERC-20 symbol()/name() eth_call. */
+export function decodeAbiString(hexResult: unknown): string | null {
+  if (typeof hexResult !== 'string' || hexResult.length <= 2) return null;
+  const h = hexResult.slice(2);
+  try {
+    // Standard ABI dynamic string: [offset][length][bytes...]. Offset is 0x20.
+    const len = parseInt(h.slice(64, 128), 16);
+    if (!Number.isFinite(len) || len <= 0 || len > 256) return null;
+    const s = Buffer.from(h.slice(128, 128 + len * 2), 'hex').toString('utf8').replace(/\0+$/, '').trim();
+    return s.length > 0 && s.length <= 64 ? s : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read an ERC-20/LEP-100 token's symbol and name directly from the chain.
+ *
+ * Used as a last-resort enrichment when a token contract isn't in the indexer's
+ * `contracts` table yet — otherwise a transfer of a valid-but-unindexed token
+ * renders as a bare hex pill with no name. Cached because many tx views can hit
+ * the same contract. Selectors: symbol() 0x95d89b41, name() 0x06fdde03.
+ */
+async function fetchTokenMetaOnchain(addr: string): Promise<{ symbol?: string; name?: string } | null> {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(addr) || EVM_RPC_ENDPOINTS.length === 0) return null;
+  return loadCached(`token-meta:${addr.toLowerCase()}`, EVM_ENRICH_TTL_MS, async () => {
+    try {
+      const [symRes, nameRes] = await Promise.all([
+        evmRpcCall('eth_call', [{ to: addr, data: '0x95d89b41' }, 'latest']),
+        evmRpcCall('eth_call', [{ to: addr, data: '0x06fdde03' }, 'latest']),
+      ]);
+      const symbol = decodeAbiString(symRes) ?? undefined;
+      const name = decodeAbiString(nameRes) ?? undefined;
+      return symbol || name ? { symbol, name } : null;
+    } catch {
+      return null;
+    }
+  });
+}
+
 // Live gas-price cache: eth_gasPrice every poll would needlessly hammer the RPC
 // when the homepage is open in many tabs. Cache the most recent value for a
 // short window — the homepage poll is faster than the cache TTL, so users
@@ -1247,6 +1287,13 @@ async function enrichTokenInfo<T extends { tokenTransferAmount?: string | null; 
     );
     if (rows[0]?.symbol) {
       return { ...mapped, tokenSymbol: rows[0].symbol, contractAddress: mapped.evmToAddr };
+    }
+    // Not in the contracts table — the token is real on-chain but unindexed.
+    // Read symbol()/name() live so the transfer shows a token name instead of a
+    // bare hex pill. Falls through to contractAddress-only if the read fails.
+    const meta = await fetchTokenMetaOnchain(mapped.evmToAddr);
+    if (meta?.symbol) {
+      return { ...mapped, tokenSymbol: meta.symbol, tokenName: meta.name, contractAddress: mapped.evmToAddr } as T;
     }
     // No symbol found but we know the contract — set contractAddress so the frontend
     // renders a contract link instead of falling back to the misleading "X LITHO" label.

--- a/Makalu/explorer/pages/address/[address].tsx
+++ b/Makalu/explorer/pages/address/[address].tsx
@@ -695,8 +695,8 @@ function HoldersTab({ addr, tokenDetail }: { addr: string; tokenDetail?: ApiToke
           <div key={h.address} className="grid grid-cols-1 md:grid-cols-[0.4fr_2fr_1.2fr_0.8fr] gap-3 md:gap-4 px-5 py-4 border-b border-white/5 hover:bg-white/[0.03] transition">
             <div className="text-sm text-white/40">{offset + i + 1}</div>
             <div>
-              <Link href={`/address/${h.address}`} className="font-mono text-sm text-emerald-300 hover:text-emerald-200 transition truncate">
-                {h.address}
+              <Link href={`/address/${preferLitho(h.address)}`} className="font-mono text-sm text-emerald-300 hover:text-emerald-200 transition truncate" title={`${preferLitho(h.address)}\n${h.address}`}>
+                {preferLitho(h.address)}
               </Link>
             </div>
             <div className="text-sm font-mono text-white/80 md:text-right">

--- a/Makalu/explorer/pages/token/[address].tsx
+++ b/Makalu/explorer/pages/token/[address].tsx
@@ -425,10 +425,11 @@ function HoldersTab({ address, decimals, symbol, totalSupply }: { address: strin
             {/* Address */}
             <div className="flex items-center">
               <Link
-                href={`/address/${h.address}`}
+                href={`/address/${preferLitho(h.address)}`}
                 className="font-mono text-sm text-emerald-300 hover:text-emerald-200 transition truncate"
+                title={`${preferLitho(h.address)}\n${h.address}`}
               >
-                {h.address}
+                {preferLitho(h.address)}
               </Link>
             </div>
 


### PR DESCRIPTION
Two issues from feedback on the deployed site.

## 1. Token holder addresses were raw `0x`

The **Holders** tab on both `/token/:address` and `/address/:address` rendered `h.address` (`0x`) directly. Both now lead with the bech32 form via `preferLitho`, `0x` kept in the tooltip — matching every other address surface.

## 2. Token name missing on tx pages for unindexed tokens

Transfer tx [`7D89…7E52`](https://makalu.litho.ai/txs/7D89B04845120662ACFF10E2C399C998C189A76F7A9E5C4B28ECE16DB1237E52) rendered its token as **"30,000,000 `0x71ce...de73`"** — a bare hex pill, no name.

Root cause: that contract (`0x71ce67fc…`) is a **real, live token** — `symbol()` → `FGPT`, `name()` → `FurGPT` — but it isn't in the indexer's `contracts` table, so the API returned `tokenSymbol: null`.

`enrichTokenInfo` already falls back to a `contracts`-table symbol lookup by `evmToAddr`. When that misses, it now reads `symbol()`/`name()` **directly from the chain** (`fetchTokenMetaOnchain`) before giving up — mirroring the existing live balance/gas enrichment. Cached (`EVM_ENRICH_TTL_MS`) since many tx views hit the same contract.

**No regression risk:** already-indexed tokens short-circuit on the DB lookup and never reach the RPC path; every failure degrades to the previous `contractAddress`-only rendering.

`decodeAbiString` parses the ABI return, guarding empty strings and implausible length claims.

## Verification

- API **147 + 5 new** `decodeAbiString` tests, built from the real FGPT/FurGPT ABI payloads; explorer **97**.
- OpenAPI still in sync at **34 endpoints** (no route change); build compiles.

## Caveats

- **Not fixed:** *why* FurGPT is unindexed. This makes the explorer resilient to the gap; the indexer's token-detection gap is a separate issue worth investigating (there may be more such tokens).
- The holders display and the on-chain read are verified independently, but the **enrichment path end-to-end needs a browser check against production** once deployed — I have no live DB locally.