### PR TITLE
feat(explorer): cross-chain token swap saga (/cross-swap)

### DIFF
--- a/Makalu/explorer/lib/crossSwap.ts
+++ b/Makalu/explorer/lib/crossSwap.ts
@@ -1,0 +1,380 @@
+/**
+ * Cross-chain token swap — the saga that composes the MultX bridge with the
+ * Lithoswap DEX so a user can go from token A on chain X to token B on chain Y.
+ *
+ * The DEX lives on Makalu, and the bridge locks only on the Lithosphere chains
+ * (Makalu/Kamet), so a full route is up to three legs:
+ *
+ *   bridge_in (X → Makalu)  →  swap (A → B on Makalu)  →  bridge_out (Makalu → Y)
+ *
+ * Legs whose chain is already Makalu are dropped. Each bridge leg is itself
+ * multi-step (lock → wait for validator signatures → claim), and claims on
+ * external chains are relayer-driven rather than user-submitted.
+ *
+ * This is a long-running, multi-signature, multi-chain flow, so the whole saga
+ * is a persisted state machine: every completed leg is written to localStorage,
+ * and `currentStep()` recomputes the next action from that record — so a user
+ * who closes the tab mid-flow resumes exactly where they left off. This module
+ * is the logic; pages/cross-swap.tsx drives it and owns the wallet/chain UX.
+ */
+import { Contract, JsonRpcProvider, formatUnits, parseUnits, type Eip1193Provider } from 'ethers';
+import {
+  BRIDGE_TOKENS,
+  approveIfNeeded,
+  chainByKey,
+  fetchSignatures,
+  fetchStatus,
+  lockTokens,
+  releaseTokens,
+  tokenAddressFor,
+  type BridgeToken,
+  type ChainInfo,
+} from '@/lib/bridge';
+import {
+  MAKALU_RPC,
+  SWAP_ROUTER,
+  ensureAllowance,
+  getQuote,
+  minOut,
+  swapExactTokensForTokens,
+} from '@/lib/swap';
+
+export type Phase = 'bridge_in' | 'swap' | 'bridge_out';
+
+export type StepKind =
+  | 'bridge_in_lock'
+  | 'bridge_in_claim'
+  | 'swap'
+  | 'bridge_out_lock'
+  | 'bridge_out_claim'
+  | 'await_relayer'
+  | 'done';
+
+export interface SagaConfig {
+  symbolIn: string;
+  symbolOut: string;
+  /** Source chain key — must be a lock-capable Lithosphere chain (makalu|kamet). */
+  chainXKey: string;
+  /** Destination chain key (makalu|kamet|sepolia|base|bnb). */
+  chainYKey: string;
+  /** Human input amount of token A. */
+  amountIn: string;
+  slippageBps: number;
+}
+
+interface BridgeLeg {
+  bridgeTxHash?: string;
+  ethTxHash?: string;
+  releaseTxHash?: string;
+  claimed?: boolean;
+}
+
+export interface SagaState {
+  id: string;
+  createdAt: number;
+  config: SagaConfig;
+  plan: Phase[];
+  bridgeIn?: BridgeLeg;
+  swap?: { txHash?: string; receivedB?: string /* wei, as string */ };
+  bridgeOut?: BridgeLeg;
+  status: 'active' | 'completed' | 'failed';
+  error?: string;
+}
+
+const STORAGE_KEY = 'litho_crossswap_active';
+const ERC20_BAL_ABI = ['function balanceOf(address) view returns (uint256)'];
+
+// ── Lookups ──────────────────────────────────────────────────────────────────
+
+export function tokenBySymbol(symbol: string): BridgeToken {
+  return BRIDGE_TOKENS.find((t) => t.symbol === symbol) ?? BRIDGE_TOKENS[0];
+}
+
+function chain(key: string): ChainInfo {
+  const c = chainByKey(key);
+  if (!c) throw new Error(`Unknown chain: ${key}`);
+  return c;
+}
+
+/** Source chains a cross-swap can start from: the lock-capable Lithosphere chains. */
+export const SOURCE_CHAIN_KEYS = ['makalu', 'kamet'] as const;
+
+// ── Planning ─────────────────────────────────────────────────────────────────
+
+/** The ordered legs for a route. Swap always runs on Makalu. */
+export function planRoute(chainXKey: string, chainYKey: string): Phase[] {
+  const plan: Phase[] = [];
+  if (chainXKey !== 'makalu') plan.push('bridge_in');
+  plan.push('swap');
+  if (chainYKey !== 'makalu') plan.push('bridge_out');
+  return plan;
+}
+
+function makeId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function createSaga(config: SagaConfig): SagaState {
+  return {
+    id: makeId(),
+    createdAt: Date.now(),
+    config,
+    plan: planRoute(config.chainXKey, config.chainYKey),
+    status: 'active',
+  };
+}
+
+// ── Persistence (one active saga at a time) ──────────────────────────────────
+
+export function saveSaga(saga: SagaState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(saga));
+  } catch {
+    /* storage unavailable — caller keeps it in memory */
+  }
+}
+
+export function loadSaga(): SagaState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SagaState) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSaga(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+// ── Step machine ─────────────────────────────────────────────────────────────
+
+/** The next action the saga needs, derived purely from its persisted record. */
+export function currentStep(saga: SagaState): StepKind {
+  const hasBridgeIn = saga.plan.includes('bridge_in');
+  const hasBridgeOut = saga.plan.includes('bridge_out');
+
+  if (hasBridgeIn && !saga.bridgeIn?.claimed) {
+    return saga.bridgeIn?.bridgeTxHash ? 'bridge_in_claim' : 'bridge_in_lock';
+  }
+  if (!saga.swap?.txHash) {
+    return 'swap';
+  }
+  if (hasBridgeOut) {
+    const destLitho = chain(saga.config.chainYKey).litho;
+    if (!saga.bridgeOut?.bridgeTxHash) return 'bridge_out_lock';
+    if (destLitho) {
+      if (!saga.bridgeOut?.claimed) return 'bridge_out_claim';
+    } else {
+      // External destination: the relayer releases; we only wait.
+      if (!saga.bridgeOut?.releaseTxHash) return 'await_relayer';
+    }
+  }
+  return 'done';
+}
+
+export interface StepInfo {
+  kind: StepKind;
+  /** Chain the user's wallet must be on for this step (null = no user tx). */
+  chainKey: string | null;
+  chainId: number | null;
+  title: string;
+  /** Bridge internal hash to poll for signatures/relayer, when relevant. */
+  bridgeTxHash?: string;
+}
+
+export function describeStep(saga: SagaState): StepInfo {
+  const kind = currentStep(saga);
+  const x = chain(saga.config.chainXKey);
+  const y = chain(saga.config.chainYKey);
+  const mk = chain('makalu');
+  const { symbolIn, symbolOut } = saga.config;
+
+  switch (kind) {
+    case 'bridge_in_lock':
+      return { kind, chainKey: x.key, chainId: x.chainId, title: `Lock ${symbolIn} on ${x.name}` };
+    case 'bridge_in_claim':
+      return {
+        kind,
+        chainKey: mk.key,
+        chainId: mk.chainId,
+        title: `Claim ${symbolIn} on ${mk.name}`,
+        bridgeTxHash: saga.bridgeIn?.bridgeTxHash,
+      };
+    case 'swap':
+      return { kind, chainKey: mk.key, chainId: mk.chainId, title: `Swap ${symbolIn} → ${symbolOut} on ${mk.name}` };
+    case 'bridge_out_lock':
+      return { kind, chainKey: mk.key, chainId: mk.chainId, title: `Lock ${symbolOut} on ${mk.name}` };
+    case 'bridge_out_claim':
+      return {
+        kind,
+        chainKey: y.key,
+        chainId: y.chainId,
+        title: `Claim ${symbolOut} on ${y.name}`,
+        bridgeTxHash: saga.bridgeOut?.bridgeTxHash,
+      };
+    case 'await_relayer':
+      return {
+        kind,
+        chainKey: null,
+        chainId: null,
+        title: `Waiting for the relayer to release ${symbolOut} on ${y.name}`,
+        bridgeTxHash: saga.bridgeOut?.bridgeTxHash,
+      };
+    case 'done':
+      return { kind, chainKey: null, chainId: null, title: 'Complete' };
+  }
+}
+
+// ── Balance helper (Makalu) ──────────────────────────────────────────────────
+
+async function makaluBalance(token: string, owner: string): Promise<bigint> {
+  const provider = new JsonRpcProvider(MAKALU_RPC);
+  const erc20 = new Contract(token, ERC20_BAL_ABI, provider);
+  return (await erc20.balanceOf(owner)) as bigint;
+}
+
+// ── Executors — each performs ONE user-facing step and returns the new saga ──
+
+export async function runBridgeInLock(
+  saga: SagaState,
+  walletProvider: Eip1193Provider,
+): Promise<SagaState> {
+  const token = tokenBySymbol(saga.config.symbolIn);
+  const source = chain(saga.config.chainXKey);
+  const makalu = chain('makalu');
+  const tokenAddr = tokenAddressFor(token, source.key);
+
+  await approveIfNeeded(walletProvider, tokenAddr, source.bridge, parseUnits(saga.config.amountIn, token.decimals));
+  const { ethTxHash, bridgeTxHash } = await lockTokens(
+    walletProvider,
+    source.bridge,
+    tokenAddr,
+    saga.config.amountIn,
+    token.decimals,
+    makalu.chainId,
+  );
+  return { ...saga, bridgeIn: { ...saga.bridgeIn, ethTxHash, bridgeTxHash } };
+}
+
+/** Returns true once enough validator signatures exist to claim. */
+export async function claimReady(bridgeTxHash: string): Promise<boolean> {
+  const status = await fetchStatus(bridgeTxHash);
+  if (!status) return false;
+  if (status.status === 'completed' || status.releaseTxHash) return true;
+  return status.signaturesCollected >= status.signaturesRequired && status.signaturesRequired > 0;
+}
+
+export async function runBridgeInClaim(
+  saga: SagaState,
+  walletProvider: Eip1193Provider,
+): Promise<SagaState> {
+  const hash = saga.bridgeIn?.bridgeTxHash;
+  if (!hash) throw new Error('No bridge-in transaction to claim');
+  const status = await fetchStatus(hash);
+  if (!status) throw new Error('Bridge status unavailable — try again shortly');
+  const makalu = chain('makalu');
+
+  if (status.status === 'completed' || status.releaseTxHash) {
+    return { ...saga, bridgeIn: { ...saga.bridgeIn, claimed: true, releaseTxHash: status.releaseTxHash ?? undefined } };
+  }
+  const sigs = await fetchSignatures(hash);
+  const releaseTxHash = await releaseTokens(walletProvider, makalu.bridge, status, sigs);
+  return { ...saga, bridgeIn: { ...saga.bridgeIn, claimed: true, releaseTxHash } };
+}
+
+export async function runSwap(
+  saga: SagaState,
+  walletProvider: Eip1193Provider,
+  address: string,
+): Promise<SagaState> {
+  const tokenIn = tokenBySymbol(saga.config.symbolIn);
+  const tokenOut = tokenBySymbol(saga.config.symbolOut);
+
+  const before = await makaluBalance(tokenOut.makalu, address);
+  const quote = await getQuote(saga.config.amountIn, tokenIn.makalu, tokenIn.decimals, tokenOut.makalu);
+  if (!quote) throw new Error('No swap route/liquidity for this pair on Makalu');
+
+  const amountIn = parseUnits(saga.config.amountIn, tokenIn.decimals);
+  await ensureAllowance(walletProvider, tokenIn.makalu, amountIn);
+  const txHash = await swapExactTokensForTokens(
+    walletProvider,
+    tokenIn.makalu,
+    tokenOut.makalu,
+    saga.config.amountIn,
+    tokenIn.decimals,
+    minOut(quote.amountOut, saga.config.slippageBps),
+    address,
+  );
+  const after = await makaluBalance(tokenOut.makalu, address);
+  const receivedB = (after - before).toString();
+  return { ...saga, swap: { txHash, receivedB } };
+}
+
+export async function runBridgeOutLock(
+  saga: SagaState,
+  walletProvider: Eip1193Provider,
+): Promise<SagaState> {
+  const token = tokenBySymbol(saga.config.symbolOut);
+  const makalu = chain('makalu');
+  const dest = chain(saga.config.chainYKey);
+  const receivedWei = BigInt(saga.swap?.receivedB ?? '0');
+  if (receivedWei <= BigInt(0)) throw new Error('No swapped balance to bridge out');
+  const amountHuman = formatUnits(receivedWei, token.decimals);
+
+  await approveIfNeeded(walletProvider, token.makalu, makalu.bridge, receivedWei);
+  const { ethTxHash, bridgeTxHash } = await lockTokens(
+    walletProvider,
+    makalu.bridge,
+    token.makalu,
+    amountHuman,
+    token.decimals,
+    dest.chainId,
+  );
+  return { ...saga, bridgeOut: { ...saga.bridgeOut, ethTxHash, bridgeTxHash } };
+}
+
+export async function runBridgeOutClaim(
+  saga: SagaState,
+  walletProvider: Eip1193Provider,
+): Promise<SagaState> {
+  const hash = saga.bridgeOut?.bridgeTxHash;
+  if (!hash) throw new Error('No bridge-out transaction to claim');
+  const status = await fetchStatus(hash);
+  if (!status) throw new Error('Bridge status unavailable — try again shortly');
+  const dest = chain(saga.config.chainYKey);
+
+  if (status.status === 'completed' || status.releaseTxHash) {
+    return { ...saga, bridgeOut: { ...saga.bridgeOut, claimed: true, releaseTxHash: status.releaseTxHash ?? undefined } };
+  }
+  const sigs = await fetchSignatures(hash);
+  const releaseTxHash = await releaseTokens(walletProvider, dest.bridge, status, sigs);
+  return { ...saga, bridgeOut: { ...saga.bridgeOut, claimed: true, releaseTxHash } };
+}
+
+/** Poll an external-chain bridge-out for relayer completion. */
+export async function pollRelayer(saga: SagaState): Promise<SagaState> {
+  const hash = saga.bridgeOut?.bridgeTxHash;
+  if (!hash) return saga;
+  const status = await fetchStatus(hash);
+  if (status && (status.status === 'completed' || status.releaseTxHash)) {
+    return { ...saga, bridgeOut: { ...saga.bridgeOut, releaseTxHash: status.releaseTxHash ?? undefined } };
+  }
+  return saga;
+}
+
+/** True when the saga has no remaining steps. */
+export function isComplete(saga: SagaState): boolean {
+  return currentStep(saga) === 'done';
+}
+
+export function isCrossSwapConfigured(): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(SWAP_ROUTER);
+}

--- a/Makalu/explorer/pages/cross-swap.tsx
+++ b/Makalu/explorer/pages/cross-swap.tsx
@@ -1,0 +1,468 @@
+import Head from 'next/head';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useWeb3Modal, useWeb3ModalAccount, useWeb3ModalProvider } from '@web3modal/ethers/react';
+import { type Eip1193Provider } from 'ethers';
+import { EXPLORER_TITLE } from '@/lib/constants';
+import { BRIDGE_CHAIN_LIST, BRIDGE_TOKENS, chainByKey, describeBridgeError } from '@/lib/bridge';
+import { formatAmount, getQuote, describeSwapError } from '@/lib/swap';
+import {
+  SOURCE_CHAIN_KEYS,
+  claimReady,
+  createSaga,
+  clearSaga,
+  currentStep,
+  describeStep,
+  isComplete,
+  isCrossSwapConfigured,
+  loadSaga,
+  planRoute,
+  pollRelayer,
+  runBridgeInClaim,
+  runBridgeInLock,
+  runBridgeOutClaim,
+  runBridgeOutLock,
+  runSwap,
+  saveSaga,
+  tokenBySymbol,
+  type SagaState,
+} from '@/lib/crossSwap';
+
+const PRIMARY_CTA =
+  'w-full rounded-2xl border border-sky-300/20 bg-gradient-to-r from-[#1cc7ff] via-[#227dff] to-[#3157ff] px-5 py-3 text-sm font-medium text-white shadow-[0_18px_40px_rgba(37,99,235,0.35)] transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0';
+const SELECT =
+  'w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white outline-none focus:border-sky-400/50';
+const SLIPPAGE_OPTIONS = [10, 50, 100];
+
+const CHAIN_PARAMS: Record<number, {
+  chainId: string;
+  chainName: string;
+  rpcUrls: string[];
+  nativeCurrency: { name: string; symbol: string; decimals: number };
+  blockExplorerUrls: string[];
+}> = {
+  700777: {
+    chainId: '0x' + (700777).toString(16),
+    chainName: 'Lithosphere Makalu',
+    rpcUrls: ['https://rpc.litho.ai'],
+    nativeCurrency: { name: 'LITHO', symbol: 'LITHO', decimals: 18 },
+    blockExplorerUrls: ['https://makalu.litho.ai'],
+  },
+  900523: {
+    chainId: '0x' + (900523).toString(16),
+    chainName: 'Lithosphere Kamet',
+    rpcUrls: ['https://rpc-3.litho.ai'],
+    nativeCurrency: { name: 'LITHO', symbol: 'LITHO', decimals: 18 },
+    blockExplorerUrls: ['https://kamet.litho.ai'],
+  },
+};
+
+function CrossSwapContent() {
+  const { open } = useWeb3Modal();
+  const { isConnected, address } = useWeb3ModalAccount();
+  const { walletProvider } = useWeb3ModalProvider();
+
+  const configured = isCrossSwapConfigured();
+
+  const [saga, setSaga] = useState<SagaState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState('');
+  const [statusType, setStatusType] = useState<'info' | 'error' | 'success'>('info');
+  const [ready, setReady] = useState(false); // claim-readiness for the current bridge leg
+
+  // Setup form
+  const [symbolIn, setSymbolIn] = useState(BRIDGE_TOKENS[0].symbol);
+  const [symbolOut, setSymbolOut] = useState(BRIDGE_TOKENS[2]?.symbol ?? BRIDGE_TOKENS[1].symbol);
+  const [chainXKey, setChainXKey] = useState('kamet');
+  const [chainYKey, setChainYKey] = useState('makalu');
+  const [amount, setAmount] = useState('1');
+  const [slippageBps, setSlippageBps] = useState(50);
+  const [previewOut, setPreviewOut] = useState<string>('—');
+
+  function show(msg: string, type: 'info' | 'error' | 'success' = 'info') {
+    setStatus(msg);
+    setStatusType(type);
+  }
+
+  // Restore an in-flight saga on mount.
+  useEffect(() => {
+    const existing = loadSaga();
+    if (existing && existing.status === 'active') setSaga(existing);
+  }, []);
+
+  const tokenIn = useMemo(() => tokenBySymbol(symbolIn), [symbolIn]);
+  const tokenOut = useMemo(() => tokenBySymbol(symbolOut), [symbolOut]);
+  const sameToken = tokenIn.symbol === tokenOut.symbol;
+  const plan = useMemo(() => planRoute(chainXKey, chainYKey), [chainXKey, chainYKey]);
+
+  // Live quote preview (on Makalu, where the swap runs).
+  useEffect(() => {
+    if (saga || !configured || sameToken || !/^\d+(\.\d+)?$/.test(amount) || Number(amount) <= 0) {
+      setPreviewOut('—');
+      return;
+    }
+    let cancelled = false;
+    const id = setTimeout(async () => {
+      try {
+        const q = await getQuote(amount, tokenIn.makalu, tokenIn.decimals, tokenOut.makalu);
+        if (!cancelled) setPreviewOut(q ? formatAmount(q.amountOut, tokenOut.decimals) : '—');
+      } catch {
+        if (!cancelled) setPreviewOut('no route');
+      }
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(id);
+    };
+  }, [amount, tokenIn, tokenOut, saga, configured, sameToken]);
+
+  const step = saga ? describeStep(saga) : null;
+
+  // Poll signature-readiness (claim steps) or relayer completion (external dest).
+  useEffect(() => {
+    if (!saga || !step) return;
+    if (step.kind === 'bridge_in_claim' || step.kind === 'bridge_out_claim') {
+      setReady(false);
+      let cancelled = false;
+      const poll = async () => {
+        if (!step.bridgeTxHash) return;
+        const r = await claimReady(step.bridgeTxHash);
+        if (!cancelled) setReady(r);
+      };
+      void poll();
+      const t = setInterval(poll, 6000);
+      return () => {
+        cancelled = true;
+        clearInterval(t);
+      };
+    }
+    if (step.kind === 'await_relayer') {
+      let cancelled = false;
+      const poll = async () => {
+        const next = await pollRelayer(saga);
+        if (!cancelled && next !== saga) {
+          saveSaga(next);
+          setSaga(next);
+        }
+      };
+      void poll();
+      const t = setInterval(poll, 8000);
+      return () => {
+        cancelled = true;
+        clearInterval(t);
+      };
+    }
+  }, [saga, step]);
+
+  const ensureChain = useCallback(
+    async (targetId: number) => {
+      if (!walletProvider) throw new Error('Wallet not connected');
+      const provider = walletProvider as Eip1193Provider;
+      const params = CHAIN_PARAMS[targetId];
+      if (!params) throw new Error(`No wallet config for chain ${targetId}`);
+      const actual = async () => Number(await provider.request({ method: 'eth_chainId' }));
+      if ((await actual()) === targetId) return;
+      try {
+        await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: params.chainId }] });
+      } catch {
+        await provider.request({ method: 'wallet_addEthereumChain', params: [params] });
+      }
+      for (let i = 0; i < 4; i++) {
+        if ((await actual()) === targetId) return;
+        await new Promise((r) => setTimeout(r, 700));
+      }
+      throw new Error(`Wallet is not on ${params.chainName}. Switch manually and retry.`);
+    },
+    [walletProvider],
+  );
+
+  function startSaga() {
+    if (!configured) return;
+    if (sameToken) {
+      show('Pick two different tokens.', 'error');
+      return;
+    }
+    const s = createSaga({ symbolIn, symbolOut, chainXKey, chainYKey, amountIn: amount, slippageBps });
+    saveSaga(s);
+    setSaga(s);
+    show('Route started — follow the steps below. You can leave and resume any time.', 'info');
+  }
+
+  function reset() {
+    clearSaga();
+    setSaga(null);
+    setReady(false);
+    show('', 'info');
+  }
+
+  async function advance() {
+    if (!saga || !step) return;
+    if (!isConnected || !walletProvider || !address) {
+      void open({ view: 'Connect' });
+      return;
+    }
+    const wp = walletProvider as Eip1193Provider;
+    setBusy(true);
+    try {
+      if (step.chainId) {
+        show(`Switching wallet to ${chainByKey(step.chainKey!)?.name ?? 'target chain'}…`);
+        await ensureChain(step.chainId);
+      }
+      let next = saga;
+      switch (step.kind) {
+        case 'bridge_in_lock':
+          show(`Locking ${saga.config.symbolIn}…`);
+          next = await runBridgeInLock(saga, wp);
+          break;
+        case 'bridge_in_claim':
+          if (!ready) {
+            show('Validators are still signing this transfer — the claim unlocks automatically.', 'info');
+            setBusy(false);
+            return;
+          }
+          show(`Claiming ${saga.config.symbolIn} on Makalu…`);
+          next = await runBridgeInClaim(saga, wp);
+          break;
+        case 'swap':
+          show(`Swapping ${saga.config.symbolIn} → ${saga.config.symbolOut}…`);
+          next = await runSwap(saga, wp, address);
+          break;
+        case 'bridge_out_lock':
+          show(`Locking ${saga.config.symbolOut} to bridge out…`);
+          next = await runBridgeOutLock(saga, wp);
+          break;
+        case 'bridge_out_claim':
+          if (!ready) {
+            show('Validators are still signing — the claim unlocks automatically.', 'info');
+            setBusy(false);
+            return;
+          }
+          show(`Claiming ${saga.config.symbolOut}…`);
+          next = await runBridgeOutClaim(saga, wp);
+          break;
+        case 'await_relayer':
+          show('The relayer releases the tokens on the destination chain — no action needed.', 'info');
+          setBusy(false);
+          return;
+        case 'done':
+          setBusy(false);
+          return;
+      }
+      if (isComplete(next)) next = { ...next, status: 'completed' };
+      saveSaga(next);
+      setSaga(next);
+      if (next.status === 'completed') show('Cross-chain swap complete 🎉', 'success');
+    } catch (err: unknown) {
+      const msg =
+        step.kind === 'swap'
+          ? describeSwapError(err, saga.config.symbolOut)
+          : describeBridgeError(err, { symbol: saga.config.symbolIn, chainName: step.chainKey ?? 'chain' });
+      show(msg, 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const statusColors = {
+    info: 'border-blue-400/20 bg-blue-400/10 text-blue-200',
+    error: 'border-red-400/20 bg-red-400/10 text-red-200',
+    success: 'border-emerald-400/20 bg-emerald-400/10 text-emerald-200',
+  };
+
+  // Visual leg status for the progress rail.
+  function legDone(phase: 'bridge_in' | 'swap' | 'bridge_out'): boolean {
+    if (!saga) return false;
+    if (phase === 'bridge_in') return !!saga.bridgeIn?.claimed;
+    if (phase === 'swap') return !!saga.swap?.txHash;
+    return chainByKey(saga.config.chainYKey)?.litho
+      ? !!saga.bridgeOut?.claimed
+      : !!saga.bridgeOut?.releaseTxHash;
+  }
+  const phaseLabel: Record<string, string> = {
+    bridge_in: 'Bridge in',
+    swap: 'Swap',
+    bridge_out: 'Bridge out',
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Cross-chain Swap | {EXPLORER_TITLE}</title>
+      </Head>
+      <div className="text-white">
+        <div className="mx-auto max-w-xl">
+          <div className="mb-8">
+            <div className="mb-3 inline-flex rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70">
+              MultX Cross-chain Swap
+            </div>
+            <h1 className="text-4xl font-semibold tracking-tight">Swap across chains</h1>
+            <p className="mt-3 max-w-lg text-base leading-7 text-white/70">
+              Go from one token on one chain to a different token on another. The route bridges to
+              Makalu, swaps on Lithoswap, then bridges out — one guided flow you can resume any time.
+            </p>
+          </div>
+
+          {!configured && (
+            <div className="mb-6 rounded-2xl border border-amber-400/20 bg-amber-400/10 p-4 text-sm text-amber-200">
+              The Lithoswap DEX isn&apos;t live on Makalu yet, so cross-chain swaps are disabled. This
+              turns on automatically once the router is deployed and pools are seeded.
+            </div>
+          )}
+          {status && (
+            <div className={`mb-6 rounded-2xl border p-4 text-sm ${statusColors[statusType]}`}>{status}</div>
+          )}
+
+          {!saga ? (
+            <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="mb-2 block text-sm text-white/70">From token</label>
+                  <select value={symbolIn} onChange={(e) => setSymbolIn(e.target.value)} className={SELECT}>
+                    {BRIDGE_TOKENS.map((t) => <option key={t.symbol} value={t.symbol}>{t.symbol}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm text-white/70">From chain</label>
+                  <select value={chainXKey} onChange={(e) => setChainXKey(e.target.value)} className={SELECT}>
+                    {SOURCE_CHAIN_KEYS.map((k) => (
+                      <option key={k} value={k}>{chainByKey(k)?.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm text-white/70">To token</label>
+                  <select value={symbolOut} onChange={(e) => setSymbolOut(e.target.value)} className={SELECT}>
+                    {BRIDGE_TOKENS.map((t) => <option key={t.symbol} value={t.symbol}>{t.symbol}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm text-white/70">To chain</label>
+                  <select value={chainYKey} onChange={(e) => setChainYKey(e.target.value)} className={SELECT}>
+                    {BRIDGE_CHAIN_LIST.filter((c) => !c.comingSoon).map((c) => (
+                      <option key={c.key} value={c.key}>{c.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <label className="mb-2 block text-sm text-white/70">Amount</label>
+                <input
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  inputMode="decimal"
+                  placeholder="0.0"
+                  className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-sky-400/50"
+                />
+              </div>
+
+              <div className="mt-4 flex items-center justify-between">
+                <span className="text-sm text-white/70">Slippage</span>
+                <div className="flex gap-2">
+                  {SLIPPAGE_OPTIONS.map((bps) => (
+                    <button
+                      key={bps}
+                      type="button"
+                      onClick={() => setSlippageBps(bps)}
+                      className={`rounded-xl border px-3 py-1.5 text-xs transition ${
+                        slippageBps === bps
+                          ? 'border-sky-400/50 bg-sky-400/15 text-white'
+                          : 'border-white/10 bg-black/30 text-white/60 hover:text-white'
+                      }`}
+                    >
+                      {bps / 100}%
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-1 rounded-2xl border border-white/10 bg-black/30 p-4 text-sm text-white/70">
+                <div className="flex justify-between">
+                  <span>Est. received (before bridge fees)</span>
+                  <span className="text-white">{previewOut} {tokenOut.symbol}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Route</span>
+                  <span className="text-white">{plan.map((p) => phaseLabel[p]).join(' → ')}</span>
+                </div>
+              </div>
+
+              {sameToken && <p className="mt-3 text-sm text-amber-200/90">Choose two different tokens.</p>}
+
+              <div className="mt-5">
+                <button onClick={startSaga} disabled={!configured || sameToken} className={PRIMARY_CTA}>
+                  {configured ? 'Start cross-chain swap' : 'Not live yet'}
+                </button>
+              </div>
+            </section>
+          ) : (
+            <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+              <div className="mb-5 flex items-center gap-2">
+                {saga.plan.map((phase, i) => (
+                  <React.Fragment key={phase}>
+                    <div
+                      className={`flex-1 rounded-xl border px-3 py-2 text-center text-xs ${
+                        legDone(phase)
+                          ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200'
+                          : step?.kind.startsWith(phase)
+                            ? 'border-sky-400/40 bg-sky-400/10 text-white'
+                            : 'border-white/10 bg-black/30 text-white/50'
+                      }`}
+                    >
+                      {legDone(phase) ? '✓ ' : ''}{phaseLabel[phase]}
+                    </div>
+                    {i < saga.plan.length - 1 && <span className="text-white/30">→</span>}
+                  </React.Fragment>
+                ))}
+              </div>
+
+              <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+                <div className="text-sm text-white/60">Current step</div>
+                <div className="mt-1 text-lg font-medium text-white">{step?.title}</div>
+                <div className="mt-1 text-sm text-white/60">
+                  {saga.config.amountIn} {saga.config.symbolIn} ({chainByKey(saga.config.chainXKey)?.name})
+                  {' → '}
+                  {saga.config.symbolOut} ({chainByKey(saga.config.chainYKey)?.name})
+                </div>
+                {(step?.kind === 'bridge_in_claim' || step?.kind === 'bridge_out_claim') && !ready && (
+                  <div className="mt-2 text-xs text-white/50">Waiting for validator signatures…</div>
+                )}
+              </div>
+
+              <div className="mt-5 flex flex-wrap gap-3">
+                {!isComplete(saga) && step?.kind !== 'await_relayer' && (
+                  <button
+                    onClick={advance}
+                    disabled={busy || ((step?.kind === 'bridge_in_claim' || step?.kind === 'bridge_out_claim') && !ready)}
+                    className={PRIMARY_CTA}
+                  >
+                    {busy ? 'Working…' : !isConnected ? 'Connect Wallet' : `Continue — ${step?.title}`}
+                  </button>
+                )}
+                {isComplete(saga) && (
+                  <button onClick={reset} className={PRIMARY_CTA}>Start another swap</button>
+                )}
+                {!isComplete(saga) && (
+                  <button
+                    onClick={reset}
+                    className="rounded-2xl border border-white/10 bg-black/30 px-5 py-3 text-sm text-white/60 transition hover:text-white"
+                  >
+                    Cancel
+                  </button>
+                )}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function CrossSwapPage() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) return null;
+  return <CrossSwapContent />;
+}

--- a/Makalu/explorer/pages/swap.tsx
+++ b/Makalu/explorer/pages/swap.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Link from 'next/link';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useWeb3Modal, useWeb3ModalAccount, useWeb3ModalProvider } from '@web3modal/ethers/react';
 import { parseUnits, type Eip1193Provider } from 'ethers';
@@ -305,6 +306,13 @@ function SwapContent() {
                       : `Swap ${tokenIn.symbol} for ${tokenOut.symbol}`}
               </button>
             </div>
+
+            <p className="mt-4 text-center text-sm text-white/50">
+              Need a different chain?{' '}
+              <Link href="/cross-swap" className="text-sky-300 underline-offset-2 hover:underline">
+                Cross-chain swap →
+              </Link>
+            </p>
           </section>
         </div>
       </div>


### PR DESCRIPTION
feat(explorer): cross-chain token swap saga (/cross-swap)

Composes the MultX bridge with the Lithoswap DEX so a user can go from token A
on chain X to token B on chain Y. The DEX is on Makalu and the bridge locks only
on the Lithosphere chains, so a full route is up to three legs:

  bridge_in (X → Makalu) → swap (A → B on Makalu) → bridge_out (Makalu → Y)

Legs whose chain is already Makalu are dropped, so Kamet→Makalu is 2 legs,
Makalu→Kamet is 2, Kamet→Sepolia is 3, etc.

- lib/crossSwap.ts — a persisted state machine: route planner, saga model,
  localStorage persistence, and step executors that reuse lib/bridge.ts
  (lock → wait for validator signatures → claim) and lib/swap.ts (quote →
  approve → swap). `currentStep()` recomputes the next action purely from the
  saved record, so a user who closes the tab mid-flow resumes exactly where they
  left off. The bridge-out amount is the *actual* swap output, captured as the
  on-chain balance delta of the received token. External-chain destinations are
  released by the relayer (no user claim); Lithosphere destinations are claimed.
- pages/cross-swap.tsx — setup form (token/chain in + out, amount, slippage,
  live quote preview + route), then a guided step-runner: a progress rail, a
  single context-aware Continue button, chain-switch gating per leg, and polling
  that auto-unlocks claims once validators sign and auto-completes external
  releases. Env-gated by NEXT_PUBLIC_SWAP_ROUTER (same as /swap) — shows a
  "not live yet" state until the DEX is deployed.
- /swap gains a link to /cross-swap.

Verified: tsc clean (aside from pre-existing build-info.test.ts) and
`next build` compiles /cross-swap as a static route.

Note: this is the orchestration + UX. It exercises the same live bridge and
(once deployed) DEX; end-to-end validation on-chain needs the DEX deployed and
pools seeded.
