### PR TITLE
feat(multx): gate paused v0.5 testnet redeployments

### DIFF
--- a/MultX/README.md
+++ b/MultX/README.md
@@ -40,6 +40,8 @@ Current immutable candidate:
 [`multx-audit-candidate-v0.5.0-20260809`](https://github.com/KaJLabs/Lithosphere/releases/tag/multx-audit-candidate-v0.5.0-20260809).
 See [`docs/MAINNET_DEPLOYMENT_GATES.md`](docs/MAINNET_DEPLOYMENT_GATES.md) for
 the fail-closed production sequence and remaining approvals.
+Use [`docs/V05_TESTNET_REDEPLOYMENT.md`](docs/V05_TESTNET_REDEPLOYMENT.md) for
+the manifest-driven, paused Kamet/Makalu candidate redeployment procedure.
 
 ## Reproducible checks
 

--- a/MultX/contracts/deployments/templates/v05-testnet-redeployment.example.json
+++ b/MultX/contracts/deployments/templates/v05-testnet-redeployment.example.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "candidate": {
+    "tag": "multx-audit-candidate-v0.5.0-20260809",
+    "commit": "620e300bce9c7d967ace6a778ba7ee84e79e5d86",
+    "multXBridgeRuntimeSha256": "6bfdb3d2c8e7ae5f26169ac8c1b982c86eded4dda74a1940cbb3e88093b11cfc"
+  },
+  "approval": {
+    "record": "<PRIVATE_REPOSITORY_APPROVAL_RECORD>",
+    "changeWindowUtc": "<APPROVED_UTC_CHANGE_WINDOW>",
+    "rollbackOwner": "<APPROVED_ROLLBACK_OWNER>"
+  },
+  "validatorSet": {
+    "validators": [
+      "<VALIDATOR_1_PUBLIC_ADDRESS>",
+      "<VALIDATOR_2_PUBLIC_ADDRESS>",
+      "<VALIDATOR_3_PUBLIC_ADDRESS>",
+      "<VALIDATOR_4_PUBLIC_ADDRESS>",
+      "<VALIDATOR_5_PUBLIC_ADDRESS>",
+      "<VALIDATOR_6_PUBLIC_ADDRESS>",
+      "<VALIDATOR_7_PUBLIC_ADDRESS>"
+    ],
+    "signaturesRequired": 5
+  },
+  "networks": {
+    "kamet": {
+      "hardhatNetwork": "litho_kamet",
+      "chainId": 900523,
+      "expectedDeployer": "<APPROVED_KAMET_DEPLOYER_ADDRESS>",
+      "governanceOwner": "<APPROVED_KAMET_GOVERNANCE_OWNER>",
+      "pauseGuardian": "<APPROVED_KAMET_PAUSE_GUARDIAN>",
+      "tokens": [
+        {
+          "symbol": "LAX",
+          "address": "0xe8f504f9cE5391Fb5968b317f0b24b8A0306ACeb",
+          "dailyCapBaseUnits": "<APPROVED_POSITIVE_BASE_UNIT_CAP>"
+        }
+      ]
+    },
+    "makalu": {
+      "hardhatNetwork": "litho_makalu",
+      "chainId": 700777,
+      "expectedDeployer": "<APPROVED_MAKALU_DEPLOYER_ADDRESS>",
+      "governanceOwner": "<APPROVED_MAKALU_GOVERNANCE_OWNER>",
+      "pauseGuardian": "<APPROVED_MAKALU_PAUSE_GUARDIAN>",
+      "tokens": [
+        {
+          "symbol": "LAX",
+          "address": "0x1Cde2Ca6c2ab8622003ebe06e382bC07850d4B8d",
+          "dailyCapBaseUnits": "<APPROVED_POSITIVE_BASE_UNIT_CAP>"
+        }
+      ]
+    }
+  }
+}

--- a/MultX/contracts/deployments/templates/v05-testnet-redeployment.example.json
+++ b/MultX/contracts/deployments/templates/v05-testnet-redeployment.example.json
@@ -7,7 +7,8 @@
   },
   "approval": {
     "record": "<PRIVATE_REPOSITORY_APPROVAL_RECORD>",
-    "changeWindowUtc": "<APPROVED_UTC_CHANGE_WINDOW>",
+    "changeWindowStartUtc": "<APPROVED_UTC_WINDOW_START>",
+    "changeWindowEndUtc": "<APPROVED_UTC_WINDOW_END>",
     "rollbackOwner": "<APPROVED_ROLLBACK_OWNER>"
   },
   "validatorSet": {

--- a/MultX/contracts/package.json
+++ b/MultX/contracts/package.json
@@ -10,6 +10,7 @@
     "coverage": "hardhat coverage",
     "deploy": "hardhat run scripts/deploy.js",
     "deploy:litho": "hardhat run scripts/deploy.js --network litho_kamet",
+    "deploy:v05-testnet": "hardhat run scripts/deploy-v05-testnet.js",
     "load:makalu": "node scripts/makalu-load-test.js",
     "fund:makalu-load-wallets": "node scripts/makalu-fund-load-wallets.js",
     "correlate:makalu-profiled-run": "node scripts/makalu-correlate-profiled-run.js"

--- a/MultX/contracts/scripts/deploy-v05-testnet.js
+++ b/MultX/contracts/scripts/deploy-v05-testnet.js
@@ -16,7 +16,13 @@
 const fs = require("fs");
 const path = require("path");
 const hre = require("hardhat");
-const { CANDIDATE, loadManifest, sha256Hex, validateManifest } = require("./v05-testnet-manifest");
+const {
+  CANDIDATE,
+  assertWithinChangeWindow,
+  loadManifest,
+  sha256Hex,
+  validateManifest,
+} = require("./v05-testnet-manifest");
 
 const waitFor = async (label, transaction) => {
   const receipt = await transaction.wait();
@@ -102,6 +108,7 @@ async function main() {
   if (process.env.APPROVED_CHANGE_RECORD !== config.approval.record) {
     throw new Error("APPROVED_CHANGE_RECORD must exactly match approval.record");
   }
+  assertWithinChangeWindow(config.approval);
 
   const wallet = new hre.ethers.Wallet(readPrivateKey(process.env.DEPLOYER_PRIVATE_KEY_FILE), provider);
   if (wallet.address !== config.network.expectedDeployer) {

--- a/MultX/contracts/scripts/deploy-v05-testnet.js
+++ b/MultX/contracts/scripts/deploy-v05-testnet.js
@@ -1,0 +1,198 @@
+/**
+ * Preflight or execute a paused MultX v0.5 testnet deployment from an approved
+ * public manifest. Private keys are read only from a protected local file.
+ *
+ * Preflight:
+ *   MULTX_DEPLOYMENT_MANIFEST=... MULTX_NETWORK_KEY=kamet \
+ *   npx hardhat run scripts/deploy-v05-testnet.js --network litho_kamet
+ *
+ * Execution additionally requires:
+ *   MULTX_EXECUTE=true
+ *   DEPLOYER_PRIVATE_KEY_FILE=/protected/path/deployer.key
+ *   APPROVED_MANIFEST_SHA256=<sha256>
+ *   APPROVED_CHANGE_RECORD=<exact manifest approval.record>
+ */
+
+const fs = require("fs");
+const path = require("path");
+const hre = require("hardhat");
+const { CANDIDATE, loadManifest, sha256Hex, validateManifest } = require("./v05-testnet-manifest");
+
+const waitFor = async (label, transaction) => {
+  const receipt = await transaction.wait();
+  if (receipt.status !== 1) throw new Error(`${label} transaction failed`);
+  console.log(`${label}: ${transaction.hash} (block ${receipt.blockNumber})`);
+  return { hash: transaction.hash, blockNumber: receipt.blockNumber };
+};
+
+const artifactRuntime = async () => {
+  const artifact = await hre.artifacts.readArtifact("MultXBridge");
+  const bytes = Buffer.from(artifact.deployedBytecode.slice(2), "hex");
+  const sha256 = sha256Hex(bytes);
+  if (sha256 !== CANDIDATE.multXBridgeRuntimeSha256) {
+    throw new Error(`compiled MultXBridge runtime SHA-256 ${sha256} does not match candidate evidence`);
+  }
+  return { artifact, sha256, bytes: bytes.length };
+};
+
+const verifyTokens = async (provider, tokens) => {
+  const abi = ["function symbol() view returns (string)"];
+  for (const token of tokens) {
+    const code = await provider.getCode(token.address);
+    if (code === "0x") throw new Error(`${token.symbol} has no contract code at ${token.address}`);
+    const contract = new hre.ethers.Contract(token.address, abi, provider);
+    const onChainSymbol = await contract.symbol();
+    if (onChainSymbol.toUpperCase() !== token.symbol.toUpperCase()) {
+      throw new Error(`${token.address} reports symbol ${onChainSymbol}, expected ${token.symbol}`);
+    }
+  }
+};
+
+const readPrivateKey = (filePath) => {
+  if (!filePath) throw new Error("DEPLOYER_PRIVATE_KEY_FILE is required for execution");
+  const stat = fs.statSync(filePath);
+  if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+    throw new Error("DEPLOYER_PRIVATE_KEY_FILE must not be group/world accessible");
+  }
+  const value = fs.readFileSync(filePath, "utf8").trim();
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) throw new Error("deployer key file must contain one hex private key");
+  return value;
+};
+
+async function main() {
+  if (process.env.DEPLOYER_PRIVATE_KEY) {
+    throw new Error("unset DEPLOYER_PRIVATE_KEY; execution accepts DEPLOYER_PRIVATE_KEY_FILE only");
+  }
+  const networkKey = process.env.MULTX_NETWORK_KEY;
+  const { manifest, manifestSha256 } = loadManifest(process.env.MULTX_DEPLOYMENT_MANIFEST);
+  const config = validateManifest(manifest, networkKey);
+  const runtime = await artifactRuntime();
+  const provider = hre.ethers.provider;
+  const liveNetwork = await provider.getNetwork();
+
+  if (hre.network.name !== config.network.hardhatNetwork) {
+    throw new Error(`Hardhat network ${hre.network.name} does not match manifest ${config.network.hardhatNetwork}`);
+  }
+  if (liveNetwork.chainId !== config.network.chainId) {
+    throw new Error(`RPC chain ID ${liveNetwork.chainId} does not match manifest ${config.network.chainId}`);
+  }
+  await verifyTokens(provider, config.network.tokens);
+
+  const preflight = {
+    mode: process.env.MULTX_EXECUTE === "true" ? "execute" : "preflight",
+    manifestSha256,
+    network: config.network.key,
+    chainId: config.network.chainId,
+    candidate: config.candidate,
+    runtimeBytes: runtime.bytes,
+    validators: config.validatorSet.validators.length,
+    signaturesRequired: config.validatorSet.signaturesRequired,
+    supportedTokens: config.network.tokens.map(({ symbol, address, dailyCapBaseUnits }) => ({ symbol, address, dailyCapBaseUnits })),
+  };
+  console.log(JSON.stringify(preflight, null, 2));
+
+  if (process.env.MULTX_EXECUTE !== "true") {
+    console.log("Preflight passed. No transaction was signed or submitted.");
+    return;
+  }
+
+  if (process.env.APPROVED_MANIFEST_SHA256 !== manifestSha256) {
+    throw new Error("APPROVED_MANIFEST_SHA256 does not match the exact manifest file");
+  }
+  if (process.env.APPROVED_CHANGE_RECORD !== config.approval.record) {
+    throw new Error("APPROVED_CHANGE_RECORD must exactly match approval.record");
+  }
+
+  const wallet = new hre.ethers.Wallet(readPrivateKey(process.env.DEPLOYER_PRIVATE_KEY_FILE), provider);
+  if (wallet.address !== config.network.expectedDeployer) {
+    throw new Error(`deployer ${wallet.address} does not match expectedDeployer ${config.network.expectedDeployer}`);
+  }
+  if ((await wallet.getBalance()).isZero()) throw new Error("approved deployer has zero balance");
+
+  const factory = new hre.ethers.ContractFactory(runtime.artifact.abi, runtime.artifact.bytecode, wallet);
+  const bridge = await factory.deploy(
+    config.validatorSet.validators,
+    config.validatorSet.signaturesRequired,
+    { gasLimit: 7_000_000 }
+  );
+  const deployment = await waitFor("deploy", bridge.deployTransaction);
+  const transactions = { deployment };
+
+  transactions.pause = await waitFor("pause", await bridge.pause());
+  transactions.pauseGuardian = await waitFor(
+    "setPauseGuardian",
+    await bridge.setPauseGuardian(config.network.pauseGuardian)
+  );
+  transactions.tokens = [];
+  for (const token of config.network.tokens) {
+    const support = await waitFor(`addSupportedToken ${token.symbol}`, await bridge.addSupportedToken(token.address));
+    const cap = await waitFor(
+      `setDailyCap ${token.symbol}`,
+      await bridge.setDailyCap(token.address, token.dailyCapBaseUnits)
+    );
+    transactions.tokens.push({ symbol: token.symbol, support, cap });
+  }
+  if (wallet.address !== config.network.governanceOwner) {
+    transactions.transferOwnership = await waitFor(
+      "transferOwnership",
+      await bridge.transferOwnership(config.network.governanceOwner)
+    );
+  }
+
+  const deployedCode = await provider.getCode(bridge.address);
+  const deployedRuntimeSha256 = sha256Hex(Buffer.from(deployedCode.slice(2), "hex"));
+  if (deployedRuntimeSha256 !== CANDIDATE.multXBridgeRuntimeSha256) {
+    throw new Error("deployed runtime bytecode does not match the approved candidate");
+  }
+  const [paused, owner, guardian, validators, threshold] = await Promise.all([
+    bridge.paused(),
+    bridge.owner(),
+    bridge.pauseGuardian(),
+    bridge.getValidators(),
+    bridge.signaturesRequired(),
+  ]);
+  if (!paused) throw new Error("deployed bridge is not paused");
+  if (owner !== config.network.governanceOwner) throw new Error("deployed owner mismatch");
+  if (guardian !== config.network.pauseGuardian) throw new Error("deployed pause guardian mismatch");
+  if (threshold.toNumber() !== config.validatorSet.signaturesRequired) throw new Error("deployed threshold mismatch");
+  if (validators.map((v) => v.toLowerCase()).join(",") !== config.validatorSet.validators.map((v) => v.toLowerCase()).join(",")) {
+    throw new Error("deployed validator set mismatch");
+  }
+  for (const token of config.network.tokens) {
+    if (!(await bridge.supportedTokens(token.address))) throw new Error(`${token.symbol} is not supported after deployment`);
+    if (!(await bridge.dailyCap(token.address)).eq(token.dailyCapBaseUnits)) throw new Error(`${token.symbol} daily cap mismatch`);
+  }
+
+  const record = {
+    schemaVersion: 1,
+    generatedAtUtc: new Date().toISOString(),
+    candidate: config.candidate,
+    approval: config.approval,
+    approvedManifestSha256: manifestSha256,
+    network: config.network.key,
+    chainId: config.network.chainId,
+    bridge: bridge.address,
+    deployer: wallet.address,
+    governanceOwner: owner,
+    pauseGuardian: guardian,
+    paused,
+    validators,
+    signaturesRequired: threshold.toNumber(),
+    tokens: config.network.tokens,
+    runtimeSha256: deployedRuntimeSha256,
+    transactions,
+  };
+  const defaultOutput = path.resolve(
+    __dirname,
+    "../deployments",
+    `${config.network.key}-v05-${Date.now()}.json`
+  );
+  const output = path.resolve(process.env.MULTX_DEPLOYMENT_OUTPUT || defaultOutput);
+  fs.writeFileSync(output, `${JSON.stringify(record, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+  console.log(`Deployment verified and recorded at ${output}`);
+}
+
+main().then(() => process.exit(0)).catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/MultX/contracts/scripts/v05-testnet-manifest.js
+++ b/MultX/contracts/scripts/v05-testnet-manifest.js
@@ -1,0 +1,148 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const { ethers } = require("ethers");
+
+const CANDIDATE = Object.freeze({
+  tag: "multx-audit-candidate-v0.5.0-20260809",
+  commit: "620e300bce9c7d967ace6a778ba7ee84e79e5d86",
+  multXBridgeRuntimeSha256: "6bfdb3d2c8e7ae5f26169ac8c1b982c86eded4dda74a1940cbb3e88093b11cfc",
+});
+
+const NETWORKS = Object.freeze({
+  kamet: { chainId: 900523, hardhatNetwork: "litho_kamet" },
+  makalu: { chainId: 700777, hardhatNetwork: "litho_makalu" },
+});
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const requiredText = (value, field) => {
+  if (typeof value !== "string" || !value.trim() || /[<>]/.test(value)) {
+    fail(`${field} must be an approved non-placeholder value`);
+  }
+  return value.trim();
+};
+
+const utcTimestamp = (value, field) => {
+  const normalized = requiredText(value, field);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(normalized) || Number.isNaN(Date.parse(normalized))) {
+    fail(`${field} must be an exact UTC timestamp (YYYY-MM-DDTHH:MM:SSZ)`);
+  }
+  return normalized;
+};
+
+const address = (value, field) => {
+  requiredText(value, field);
+  let normalized;
+  try {
+    normalized = ethers.utils.getAddress(value);
+  } catch {
+    fail(`${field} must be a valid EVM address`);
+  }
+  if (normalized === ethers.constants.AddressZero) fail(`${field} cannot be the zero address`);
+  return normalized;
+};
+
+const positiveIntegerString = (value, field) => {
+  if (typeof value !== "string" || !/^[1-9][0-9]*$/.test(value)) {
+    fail(`${field} must be a positive base-unit integer string`);
+  }
+  return value;
+};
+
+const sha256Hex = (bytes) => crypto.createHash("sha256").update(bytes).digest("hex");
+
+const loadManifest = (manifestPath) => {
+  if (!manifestPath) fail("MULTX_DEPLOYMENT_MANIFEST is required");
+  const raw = fs.readFileSync(manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(raw.toString("utf8"));
+  } catch (error) {
+    fail(`manifest is not valid JSON: ${error.message}`);
+  }
+  return { manifest, manifestSha256: sha256Hex(raw) };
+};
+
+const validateManifest = (manifest, networkKey) => {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) fail("manifest must be an object");
+  if (manifest.schemaVersion !== 1) fail("schemaVersion must be 1");
+
+  for (const [field, expected] of Object.entries(CANDIDATE)) {
+    if (!manifest.candidate || manifest.candidate[field] !== expected) {
+      fail(`candidate.${field} must equal the immutable v0.5 candidate value`);
+    }
+  }
+
+  const approval = manifest.approval || {};
+  const normalizedApproval = {
+    record: requiredText(approval.record, "approval.record"),
+    changeWindowUtc: utcTimestamp(approval.changeWindowUtc, "approval.changeWindowUtc"),
+    rollbackOwner: requiredText(approval.rollbackOwner, "approval.rollbackOwner"),
+  };
+
+  const set = manifest.validatorSet || {};
+  if (!Array.isArray(set.validators) || set.validators.length !== 7) {
+    fail("validatorSet.validators must contain exactly seven approved addresses");
+  }
+  if (set.signaturesRequired !== 5) fail("validatorSet.signaturesRequired must be 5");
+  const validators = set.validators.map((value, index) => address(value, `validatorSet.validators[${index}]`));
+  if (new Set(validators.map((value) => value.toLowerCase())).size !== validators.length) {
+    fail("validatorSet.validators must be unique");
+  }
+
+  const expectedNetwork = NETWORKS[networkKey];
+  if (!expectedNetwork) fail("MULTX_NETWORK_KEY must be kamet or makalu");
+  const input = manifest.networks && manifest.networks[networkKey];
+  if (!input || typeof input !== "object") fail(`networks.${networkKey} is required`);
+  if (input.chainId !== expectedNetwork.chainId) fail(`networks.${networkKey}.chainId must be ${expectedNetwork.chainId}`);
+  if (input.hardhatNetwork !== expectedNetwork.hardhatNetwork) {
+    fail(`networks.${networkKey}.hardhatNetwork must be ${expectedNetwork.hardhatNetwork}`);
+  }
+
+  const expectedDeployer = address(input.expectedDeployer, `networks.${networkKey}.expectedDeployer`);
+  const governanceOwner = address(input.governanceOwner, `networks.${networkKey}.governanceOwner`);
+  const pauseGuardian = address(input.pauseGuardian, `networks.${networkKey}.pauseGuardian`);
+  if (governanceOwner === pauseGuardian) fail("governanceOwner and pauseGuardian must be independent addresses");
+  const roleAddresses = new Set([expectedDeployer, governanceOwner, pauseGuardian].map((value) => value.toLowerCase()));
+  if (roleAddresses.size !== 3) fail("expectedDeployer, governanceOwner, and pauseGuardian must be independent addresses");
+  if (validators.some((value) => roleAddresses.has(value.toLowerCase()))) {
+    fail("bridge validators must be independent from deployer and governance roles");
+  }
+
+  if (!Array.isArray(input.tokens) || input.tokens.length === 0) {
+    fail(`networks.${networkKey}.tokens must contain at least one approved token`);
+  }
+  const symbols = new Set();
+  const tokenAddresses = new Set();
+  const tokens = input.tokens.map((token, index) => {
+    if (!token || typeof token !== "object") fail(`tokens[${index}] must be an object`);
+    const symbol = requiredText(token.symbol, `tokens[${index}].symbol`);
+    if (!/^[A-Za-z0-9]{2,12}$/.test(symbol)) fail(`tokens[${index}].symbol is invalid`);
+    const tokenAddress = address(token.address, `tokens[${index}].address`);
+    const dailyCapBaseUnits = positiveIntegerString(token.dailyCapBaseUnits, `tokens[${index}].dailyCapBaseUnits`);
+    if (symbols.has(symbol.toUpperCase())) fail(`duplicate token symbol: ${symbol}`);
+    if (tokenAddresses.has(tokenAddress.toLowerCase())) fail(`duplicate token address: ${tokenAddress}`);
+    symbols.add(symbol.toUpperCase());
+    tokenAddresses.add(tokenAddress.toLowerCase());
+    return { symbol, address: tokenAddress, dailyCapBaseUnits };
+  });
+
+  return {
+    candidate: CANDIDATE,
+    approval: normalizedApproval,
+    validatorSet: { validators, signaturesRequired: 5 },
+    network: {
+      key: networkKey,
+      chainId: expectedNetwork.chainId,
+      hardhatNetwork: expectedNetwork.hardhatNetwork,
+      expectedDeployer,
+      governanceOwner,
+      pauseGuardian,
+      tokens,
+    },
+  };
+};
+
+module.exports = { CANDIDATE, NETWORKS, loadManifest, sha256Hex, validateManifest };

--- a/MultX/contracts/scripts/v05-testnet-manifest.js
+++ b/MultX/contracts/scripts/v05-testnet-manifest.js
@@ -32,6 +32,14 @@ const utcTimestamp = (value, field) => {
   return normalized;
 };
 
+const assertWithinChangeWindow = (approval, now = Date.now()) => {
+  const start = Date.parse(approval.changeWindowStartUtc);
+  const end = Date.parse(approval.changeWindowEndUtc);
+  if (!Number.isFinite(now) || now < start || now > end) {
+    fail("execution is outside the approved UTC change window");
+  }
+};
+
 const address = (value, field) => {
   requiredText(value, field);
   let normalized;
@@ -78,9 +86,13 @@ const validateManifest = (manifest, networkKey) => {
   const approval = manifest.approval || {};
   const normalizedApproval = {
     record: requiredText(approval.record, "approval.record"),
-    changeWindowUtc: utcTimestamp(approval.changeWindowUtc, "approval.changeWindowUtc"),
+    changeWindowStartUtc: utcTimestamp(approval.changeWindowStartUtc, "approval.changeWindowStartUtc"),
+    changeWindowEndUtc: utcTimestamp(approval.changeWindowEndUtc, "approval.changeWindowEndUtc"),
     rollbackOwner: requiredText(approval.rollbackOwner, "approval.rollbackOwner"),
   };
+  if (Date.parse(normalizedApproval.changeWindowEndUtc) <= Date.parse(normalizedApproval.changeWindowStartUtc)) {
+    fail("approval.changeWindowEndUtc must be after approval.changeWindowStartUtc");
+  }
 
   const set = manifest.validatorSet || {};
   if (!Array.isArray(set.validators) || set.validators.length !== 7) {
@@ -145,4 +157,11 @@ const validateManifest = (manifest, networkKey) => {
   };
 };
 
-module.exports = { CANDIDATE, NETWORKS, loadManifest, sha256Hex, validateManifest };
+module.exports = {
+  CANDIDATE,
+  NETWORKS,
+  assertWithinChangeWindow,
+  loadManifest,
+  sha256Hex,
+  validateManifest,
+};

--- a/MultX/contracts/test/V05TestnetManifest.test.js
+++ b/MultX/contracts/test/V05TestnetManifest.test.js
@@ -1,5 +1,9 @@
 const { expect } = require("chai");
-const { CANDIDATE, validateManifest } = require("../scripts/v05-testnet-manifest");
+const {
+  CANDIDATE,
+  assertWithinChangeWindow,
+  validateManifest,
+} = require("../scripts/v05-testnet-manifest");
 
 const addresses = [
   "0x0000000000000000000000000000000000000001",
@@ -14,7 +18,12 @@ const addresses = [
 const manifest = () => ({
   schemaVersion: 1,
   candidate: { ...CANDIDATE },
-  approval: { record: "private-issue-2", changeWindowUtc: "2026-08-20T20:00:00Z", rollbackOwner: "kaj-labs-ops" },
+  approval: {
+    record: "private-issue-2",
+    changeWindowStartUtc: "2026-08-20T20:00:00Z",
+    changeWindowEndUtc: "2026-08-20T21:00:00Z",
+    rollbackOwner: "kaj-labs-ops",
+  },
   validatorSet: { validators: [...addresses], signaturesRequired: 5 },
   networks: {
     kamet: {
@@ -63,10 +72,19 @@ describe("v0.5 testnet deployment manifest", function () {
     expect(() => validateManifest(input, "kamet")).to.throw("independent addresses");
   });
 
-  it("requires an exact UTC change window", function () {
+  it("requires an ordered exact UTC change window", function () {
     const input = manifest();
-    input.approval.changeWindowUtc = "next Thursday";
+    input.approval.changeWindowStartUtc = "next Thursday";
     expect(() => validateManifest(input, "kamet")).to.throw("exact UTC timestamp");
+    input.approval.changeWindowStartUtc = "2026-08-20T22:00:00Z";
+    expect(() => validateManifest(input, "kamet")).to.throw("must be after");
+  });
+
+  it("blocks execution before and after the approved window", function () {
+    const approval = validateManifest(manifest(), "kamet").approval;
+    expect(() => assertWithinChangeWindow(approval, Date.parse("2026-08-20T20:30:00Z"))).not.to.throw();
+    expect(() => assertWithinChangeWindow(approval, Date.parse("2026-08-20T19:59:59Z"))).to.throw("outside");
+    expect(() => assertWithinChangeWindow(approval, Date.parse("2026-08-20T21:00:01Z"))).to.throw("outside");
   });
 
   it("separates bridge validators from deployer and governance roles", function () {

--- a/MultX/contracts/test/V05TestnetManifest.test.js
+++ b/MultX/contracts/test/V05TestnetManifest.test.js
@@ -1,0 +1,77 @@
+const { expect } = require("chai");
+const { CANDIDATE, validateManifest } = require("../scripts/v05-testnet-manifest");
+
+const addresses = [
+  "0x0000000000000000000000000000000000000001",
+  "0x0000000000000000000000000000000000000002",
+  "0x0000000000000000000000000000000000000003",
+  "0x0000000000000000000000000000000000000004",
+  "0x0000000000000000000000000000000000000005",
+  "0x0000000000000000000000000000000000000006",
+  "0x0000000000000000000000000000000000000007",
+];
+
+const manifest = () => ({
+  schemaVersion: 1,
+  candidate: { ...CANDIDATE },
+  approval: { record: "private-issue-2", changeWindowUtc: "2026-08-20T20:00:00Z", rollbackOwner: "kaj-labs-ops" },
+  validatorSet: { validators: [...addresses], signaturesRequired: 5 },
+  networks: {
+    kamet: {
+      hardhatNetwork: "litho_kamet",
+      chainId: 900523,
+      expectedDeployer: "0x0000000000000000000000000000000000000010",
+      governanceOwner: "0x0000000000000000000000000000000000000011",
+      pauseGuardian: "0x0000000000000000000000000000000000000012",
+      tokens: [{ symbol: "LAX", address: "0x0000000000000000000000000000000000000020", dailyCapBaseUnits: "1000" }],
+    },
+  },
+});
+
+describe("v0.5 testnet deployment manifest", function () {
+  it("accepts the exact candidate with a unique 5-of-7 set", function () {
+    const result = validateManifest(manifest(), "kamet");
+    expect(result.validatorSet.validators).to.have.length(7);
+    expect(result.validatorSet.signaturesRequired).to.equal(5);
+    expect(result.network.chainId).to.equal(900523);
+  });
+
+  it("rejects duplicate validators", function () {
+    const input = manifest();
+    input.validatorSet.validators[6] = input.validatorSet.validators[0];
+    expect(() => validateManifest(input, "kamet")).to.throw("must be unique");
+  });
+
+  it("rejects a candidate hash mismatch", function () {
+    const input = manifest();
+    input.candidate.multXBridgeRuntimeSha256 = "0".repeat(64);
+    expect(() => validateManifest(input, "kamet")).to.throw("immutable v0.5 candidate");
+  });
+
+  it("rejects placeholders and zero caps", function () {
+    const input = manifest();
+    input.approval.record = "<PENDING>";
+    expect(() => validateManifest(input, "kamet")).to.throw("approved non-placeholder");
+    input.approval.record = "private-issue-2";
+    input.networks.kamet.tokens[0].dailyCapBaseUnits = "0";
+    expect(() => validateManifest(input, "kamet")).to.throw("positive base-unit integer");
+  });
+
+  it("requires independent governance and pause addresses", function () {
+    const input = manifest();
+    input.networks.kamet.pauseGuardian = input.networks.kamet.governanceOwner;
+    expect(() => validateManifest(input, "kamet")).to.throw("independent addresses");
+  });
+
+  it("requires an exact UTC change window", function () {
+    const input = manifest();
+    input.approval.changeWindowUtc = "next Thursday";
+    expect(() => validateManifest(input, "kamet")).to.throw("exact UTC timestamp");
+  });
+
+  it("separates bridge validators from deployer and governance roles", function () {
+    const input = manifest();
+    input.networks.kamet.pauseGuardian = input.validatorSet.validators[0];
+    expect(() => validateManifest(input, "kamet")).to.throw("independent from deployer and governance roles");
+  });
+});

--- a/MultX/docs/V05_TESTNET_REDEPLOYMENT.md
+++ b/MultX/docs/V05_TESTNET_REDEPLOYMENT.md
@@ -1,0 +1,77 @@
+# MultX v0.5 paused testnet redeployment
+
+This procedure prepares new Kamet/Makalu testnet contracts from the immutable
+`multx-audit-candidate-v0.5.0-20260809`. It does not upgrade, overwrite, or
+mislabel the historical deployments. MultX remains disabled on LITHO mainnet.
+
+## Safety model
+
+- The exact compiled `MultXBridge` runtime SHA-256 must match the published
+  candidate evidence.
+- The manifest requires seven unique public bridge-signer addresses and a
+  5-of-7 threshold.
+- Chain ID, Hardhat network, token code, and ERC-20 symbols are checked against
+  the selected RPC before any transaction.
+- Governance owner and pause guardian must be distinct approved addresses.
+- Every supported token requires a positive, explicit base-unit daily cap.
+- Preflight is the default and signs nothing.
+- Execution requires the exact manifest SHA-256 and approval record, plus an
+  expected deployer whose private key is read from a protected local file.
+- The new bridge is paused before tokens are enabled and remains paused after
+  ownership transfer.
+- A sanitized evidence record is written only after bytecode, roles, validator
+  set, threshold, token support, caps, and paused state are verified.
+
+## Prepare an approved manifest
+
+Copy
+`contracts/deployments/templates/v05-testnet-redeployment.example.json` outside
+the public checkout or into the approved private operations repository. Add
+only approved public addresses, public token routes/caps, and approval
+references. Never add private keys, mnemonics, TLS private keys, or credentials.
+
+The example contains LAX only to avoid assuming approval for other assets.
+Add additional token entries only after their routes and caps are approved.
+
+## Preflight
+
+```bash
+cd MultX/contracts
+npm ci
+npm run compile
+
+MULTX_DEPLOYMENT_MANIFEST=/protected/approved-v05-testnet.json \
+MULTX_NETWORK_KEY=kamet \
+npx hardhat run scripts/deploy-v05-testnet.js --network litho_kamet
+```
+
+Repeat with `MULTX_NETWORK_KEY=makalu` and `--network litho_makalu` when both
+networks are approved. Record the printed manifest SHA-256 for independent
+review.
+
+## Controlled execution
+
+Execution is allowed only in the approved change window:
+
+```bash
+MULTX_DEPLOYMENT_MANIFEST=/protected/approved-v05-testnet.json \
+MULTX_NETWORK_KEY=kamet \
+MULTX_EXECUTE=true \
+DEPLOYER_PRIVATE_KEY_FILE=/protected/deployer.key \
+APPROVED_MANIFEST_SHA256=<independently-reviewed-sha256> \
+APPROVED_CHANGE_RECORD=<exact-approval-record> \
+MULTX_DEPLOYMENT_OUTPUT=/protected/kamet-v05-deployment.json \
+npx hardhat run scripts/deploy-v05-testnet.js --network litho_kamet
+```
+
+On POSIX systems the key file must not be group/world accessible. Do not put
+the key file or output directory in Git. Review and sanitize the generated
+evidence before publishing a deployment manifest.
+
+## Post-deployment gates
+
+Do not unpause after deployment. First verify independent signer mTLS,
+signature-domain separation, quorum, replay rejection, anti-equivocation
+persistence, backup restoration, monitoring, rollback, and bounded-value
+end-to-end tests. Production still requires the independent audit and written
+activation approval.

--- a/MultX/docs/V05_TESTNET_REDEPLOYMENT.md
+++ b/MultX/docs/V05_TESTNET_REDEPLOYMENT.md
@@ -15,6 +15,8 @@ mislabel the historical deployments. MultX remains disabled on LITHO mainnet.
 - Governance owner and pause guardian must be distinct approved addresses.
 - Every supported token requires a positive, explicit base-unit daily cap.
 - Preflight is the default and signs nothing.
+- Execution is rejected unless the current time is inside the manifest's exact
+  approved UTC start/end window.
 - Execution requires the exact manifest SHA-256 and approval record, plus an
   expected deployer whose private key is read from a protected local file.
 - The new bridge is paused before tokens are enabled and remains paused after


### PR DESCRIPTION
## Outcome

Adds a fail-closed, manifest-driven procedure for deploying new paused MultX v0.5 bridge contracts to Kamet and Makalu. This does not execute a deployment and does not alter historical contracts.

## Safety gates

- exact immutable v0.5 tag, commit, and compiled runtime SHA-256;
- exact chain ID and Hardhat network;
- seven unique public signer addresses with a fixed 5-of-7 threshold;
- signer separation from deployer, governance owner, and pause guardian;
- distinct deployer/governance/guardian roles;
- token code and symbol verification against live RPC;
- explicit positive per-token daily caps;
- no-signature preflight by default;
- execution key accepted only from a protected local file;
- exact manifest hash and approval-record acknowledgement;
- explicit UTC window start/end, enforced before the key is read or a transaction is signed;
- pause before enabling tokens, then verified paused state after ownership transfer;
- sanitized transaction and bytecode evidence written only after verification.

The example includes LAX only and leaves every authority/cap/approval as a failing placeholder. Other assets require separate route/cap approval.

## Validation

- 84 Hardhat tests pass after review hardening.
- Contract compilation passes.
- Candidate runtime SHA-256 reproduced exactly: `6bfdb3d2c8e7ae5f26169ac8c1b982c86eded4dda74a1940cbb3e88093b11cfc`.
- Live no-transaction preflight previously passed on Kamet chain 900523 and Makalu chain 700777.
- No transaction was signed or submitted.
- `npm audit --omit=dev` reports zero production findings. The full deployment/test toolchain audit reports 63 transitive development findings (3 critical, 14 high); keep execution isolated and complete dependency modernization before treating this toolchain as a long-lived production runner.

## External gate

Execution remains blocked on seven client-controlled public signer addresses/operators, governance roles, exact UTC window, rollback/responders, caps, approval record, dependency-toolchain disposition, and explicit activation authority. MultX remains disabled on LITHO mainnet.
