### PR TITLE
fix(indexer): isolate token registries by chain

### DIFF
--- a/Makalu/indexer/src/__tests__/token-registry.test.ts
+++ b/Makalu/indexer/src/__tests__/token-registry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KAMET_EVM_CHAIN_ID,
+  LITHO_MAINNET_EVM_CHAIN_ID,
+  MAKALU_EVM_CHAIN_ID,
+  parseConfiguredEvmChainId,
+  resolveSeededTokens,
+  resolveStaleTokenAddresses,
+} from '../token-registry.js';
+
+describe('chain-specific token registry', () => {
+  it('defaults to Makalu only when LITHO_CHAIN_ID is absent', () => {
+    expect(parseConfiguredEvmChainId(undefined)).toBe(MAKALU_EVM_CHAIN_ID);
+  });
+
+  it.each(['', '0', '-1', 'not-a-chain', '1.5', String(Number.MAX_SAFE_INTEGER + 1)])(
+    'rejects invalid configured chain ID %j',
+    (value) => {
+      expect(() => parseConfiguredEvmChainId(value)).toThrow(
+        'LITHO_CHAIN_ID must be a positive safe integer',
+      );
+    },
+  );
+
+  it('returns the canonical Makalu registry on chain 700777', () => {
+    const tokens = resolveSeededTokens(MAKALU_EVM_CHAIN_ID);
+    expect(tokens).toHaveLength(10);
+    expect(tokens.find((token) => token.symbol === 'LAX')?.address).toBe(
+      '0x1Cde2Ca6c2ab8622003ebe06e382bC07850d4B8d',
+    );
+    expect(tokens.some((token) => token.symbol === 'QTT')).toBe(false);
+  });
+
+  it('returns the RPC-verified Kamet registry on chain 900523', () => {
+    const tokens = resolveSeededTokens(KAMET_EVM_CHAIN_ID);
+    expect(tokens).toHaveLength(11);
+    expect(tokens.find((token) => token.symbol === 'LAX')?.address).toBe(
+      '0xe8f504f9cE5391Fb5968b317f0b24b8A0306ACeb',
+    );
+    expect(tokens.find((token) => token.symbol === 'QTT')?.address).toBe(
+      '0x16EE7127C9E03e29ca5727e23dd7CB03D283cDBe',
+    );
+  });
+
+  it('seeds no testnet tokens on LITHO mainnet or an unknown chain', () => {
+    expect(resolveSeededTokens(LITHO_MAINNET_EVM_CHAIN_ID)).toEqual([]);
+    expect(resolveSeededTokens(123456789)).toEqual([]);
+  });
+
+  it('marks foreign registry addresses stale without removing active addresses', () => {
+    const kametActive = new Set(
+      resolveSeededTokens(KAMET_EVM_CHAIN_ID).map((token) => token.address.toLowerCase()),
+    );
+    const kametStale = resolveStaleTokenAddresses(KAMET_EVM_CHAIN_ID);
+
+    expect(kametStale).toContain('0x1cde2ca6c2ab8622003ebe06e382bc07850d4b8d');
+    expect(kametStale).not.toContain('0xe8f504f9ce5391fb5968b317f0b24b8a0306aceb');
+    expect(kametStale.some((address) => kametActive.has(address))).toBe(false);
+
+    const mainnetStale = resolveStaleTokenAddresses(LITHO_MAINNET_EVM_CHAIN_ID);
+    expect(mainnetStale).toContain('0x1cde2ca6c2ab8622003ebe06e382bc07850d4b8d');
+    expect(mainnetStale).toContain('0xe8f504f9ce5391fb5968b317f0b24b8a0306aceb');
+  });
+});

--- a/Makalu/indexer/src/mappings.ts
+++ b/Makalu/indexer/src/mappings.ts
@@ -9,6 +9,11 @@ import { Gauge, register, collectDefaultMetrics } from 'prom-client';
 import express from 'express';
 import { readBuildInfo, buildVersionResponse } from './lib/build-info.js';
 import { logger, cycleIdStore, newCycleId } from './lib/logger.js';
+import {
+  parseConfiguredEvmChainId,
+  resolveSeededTokens,
+  resolveStaleTokenAddresses,
+} from './token-registry.js';
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 
@@ -18,6 +23,7 @@ const LCD_URL = (process.env.REST_URL || process.env.LCD_URL || RPC_URL.replace(
 const EVM_RPC_URL = (process.env.EVM_RPC_URL || '').replace(/\/$/, '');
 const PUBLIC_EVM_RPC_URL = (process.env.PUBLIC_EVM_RPC_URL || '').replace(/\/$/, '');
 const EVM_RPC_ENDPOINTS = [...new Set([EVM_RPC_URL, RPC_URL, PUBLIC_EVM_RPC_URL].filter(Boolean))];
+const EVM_CHAIN_ID = parseConfiguredEvmChainId(process.env.LITHO_CHAIN_ID);
 const START_BLOCK = parseInt(process.env.START_BLOCK || process.env.INDEXER_START_BLOCK || '1');
 const BATCH_SIZE = parseInt(process.env.BATCH_SIZE || process.env.INDEXER_BATCH_SIZE || '100');
 const POLL_MS = 6000;           // Wait between polls when caught up
@@ -104,14 +110,6 @@ interface SeedAccount {
   accountNumber: number;
 }
 
-interface SeedToken {
-  address: string;
-  name: string;
-  symbol: string;
-  decimals: number;
-  totalSupply: string;
-}
-
 interface RpcStatus {
   node_info: { network: string };
   sync_info: { latest_block_height: string };
@@ -184,46 +182,8 @@ const GENESIS_ACCOUNTS: SeedAccount[] = [
   { address: 'litho187m5cwfthxyspdzrpqvzs9c6f6k5gzenw8lkq2', evmAddress: '0x3fb74c392BB98900b443081828171a4Ead440B33', balance: '70000000000000000000000000', accountNumber: 15 },
 ];
 
-// Active LEP100 addresses deployed 2026-04-24 on lithosphere_700777-2.
-// Deployer: 0x10ed4F004Fe708014ae27Bcc20c9Ed9df3f4eadF
-const SEEDED_TOKENS: SeedToken[] = [
-  { address: '0x599a7E135f1790ae117b4EdDc0422D24Bc766161', name: 'Wrapped Lithosphere', symbol: 'wLITHO', decimals: 18, totalSupply: '1000000000000000000000000000' },
-  { address: '0xC4645CA5411D6E27556780AB4cdd0DF7e609df74', name: 'Lithosphere LitBTC', symbol: 'LitBTC', decimals: 18, totalSupply: '21000000000000000000000000' },
-  { address: '0x1Cde2Ca6c2ab8622003ebe06e382bC07850d4B8d', name: 'Lithosphere Algo', symbol: 'LAX', decimals: 18, totalSupply: '10000000000000000000000000000' },
-  { address: '0xEF2f35f6d0fb7DC9E87b8ca8252AE2E6ffb2a25e', name: 'Jot Art', symbol: 'JOT', decimals: 18, totalSupply: '1000000000000000000000000000' },
-  { address: '0x10D4BB600c96e9243E2f50baFED8b2478F25af61', name: 'Colle AI', symbol: 'COLLE', decimals: 18, totalSupply: '5000000000000000000000000000' },
-  { address: '0xAcD98E323968647936887aD4934e64B01060727e', name: 'Imagen Network', symbol: 'IMAGE', decimals: 18, totalSupply: '10000000000000000000000000000' },
-  { address: '0x10052B8ccD2160b8F9880C6b4F5DD117fF253B1c', name: 'AGII', symbol: 'AGII', decimals: 18, totalSupply: '1000000000000000000000000000' },
-  { address: '0x798eD6bFc5bfCFc60938d5098825b354427A0786', name: 'Built AI', symbol: 'BLDR', decimals: 18, totalSupply: '1000000000000000000000000000' },
-  { address: '0xDB829befCF8E582379E2c034FA2589b8D2EA1c5D', name: 'Mansa AI', symbol: 'MUSA', decimals: 18, totalSupply: '1000000000000000000000000000' },
-  { address: '0x151ef362eA96853702Cc5e7728107e3961fbD22e', name: 'FurGPT', symbol: 'FGPT', decimals: 18, totalSupply: '1000000000000000000000000000' },
-];
-
-// Legacy LEP100 addresses evicted on startup by migrateTokenAddresses():
-// - pre-reset 700777-1 contracts
-// - superseded 2026-04-21 Makalu deployment
-const STALE_TOKEN_ADDRESSES = [
-  '0xEB6cfcC84F35D6b20166cD6149Fed712ED2a7Cfe',
-  '0x468022F17CAFEBD43C18f68D53c66a1a7f0E5249',
-  '0x9611436ea7B4764Eeb1E31B83A5bF03c835Eb3e8',
-  '0x8187b232BDa461d17EA519Ba6898F7b220AAf2e2',
-  '0xE7eBf52bD714348984Fb00b4c99d9e994D60DF49',
-  '0x7a29252B13367800dD78FED47afFaB86a615c844',
-  '0x9984ad7a774218B263D74BD8A5FFEDa7DD6Fe020',
-  '0x07039884740F4DB0f71BD3bCF87a3FfA0B85A26F',
-  '0xa25c2a49893B0296977E2E70Da56AF47241d592F',
-  '0xDEE12eD9C5A1F7c29f3ab3961B892a8434A97EFa',
-  '0x93d74580a7b63a5B1FE5Aae05b7470bf9317aF9A',
-  '0xeC2B25393287025dbcdDb30659E689678c478337',
-  '0x0292C22AFC5DF714d51273BF16F9Fc3f17d97e7E',
-  '0xC0725568E86DCF6abE5729903bDF6FF999Ad52BD',
-  '0x25F70D427EB96b784ff2d0B458B6Aa5f6D251346',
-  '0xdB7b1F4b735e9f8096a44657599c9F6882ba0B0D',
-  '0xDB04AD818614a329110bdDA30c7c5e8C1Be61e45',
-  '0xb47B81370934Db2461759BD29796100fdD35e3E9',
-  '0x71ce67fCf5D130473F46DBaD05f3260A8390dE73',
-  '0x72791d72B6097D487cEC58605A62396c50C08b69',
-];
+const SEEDED_TOKENS = resolveSeededTokens(EVM_CHAIN_ID);
+const STALE_TOKEN_ADDRESSES = resolveStaleTokenAddresses(EVM_CHAIN_ID);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -575,6 +535,36 @@ async function seedGenesisAccounts(): Promise<void> {
   }
 }
 
+async function assertEvmSeedNetwork(): Promise<void> {
+  const reported = await evmRpc<string>('eth_chainId', []);
+  if (!reported || !/^0x[0-9a-f]+$/i.test(reported)) {
+    throw new Error('Unable to verify EVM chain ID before token registry migration');
+  }
+
+  const reportedChainId = Number.parseInt(reported.slice(2), 16);
+  if (reportedChainId !== EVM_CHAIN_ID) {
+    throw new Error(
+      `EVM chain ID mismatch: configured ${EVM_CHAIN_ID}, RPC reported ${reportedChainId}`,
+    );
+  }
+}
+
+async function assertSeedTokenCode(): Promise<void> {
+  const checks = await Promise.all(
+    SEEDED_TOKENS.map(async (token) => ({
+      token,
+      code: await evmRpc<string>('eth_getCode', [token.address, 'latest']),
+    })),
+  );
+  const invalid = checks
+    .filter(({ code }) => !code || code === '0x' || code === '0x0')
+    .map(({ token }) => `${token.symbol}:${token.address}`);
+
+  if (invalid.length > 0) {
+    throw new Error(`Refusing to seed token address(es) without contract code: ${invalid.join(', ')}`);
+  }
+}
+
 async function migrateTokenAddresses(): Promise<void> {
   if (STALE_TOKEN_ADDRESSES.length === 0) return;
   const placeholders = STALE_TOKEN_ADDRESSES.map((_, i) => `$${i + 1}`).join(', ');
@@ -609,12 +599,25 @@ async function seedStaticData(): Promise<void> {
   }
 
   try {
+    await assertEvmSeedNetwork();
+    await assertSeedTokenCode();
     await migrateTokenAddresses();
     await seedTokenContracts();
     const tokenCount = await pool.query("SELECT COUNT(*) AS count FROM contracts WHERE contract_type = 'token'");
-    logger.info({ count: tokenCount.rows[0]?.count ?? 0 }, '[indexer] LEP100 tokens seeded in contracts table');
+    logger.info(
+      {
+        chainId: EVM_CHAIN_ID,
+        registryTokens: SEEDED_TOKENS.length,
+        totalTokens: tokenCount.rows[0]?.count ?? 0,
+      },
+      '[indexer] Chain-specific LEP100 registry applied',
+    );
   } catch (err) {
-    logger.warn({ err: err instanceof Error ? err.message : String(err) }, '[indexer] Token seed failed (contracts table may not exist yet)');
+    logger.error(
+      { chainId: EVM_CHAIN_ID, err: err instanceof Error ? err.message : String(err) },
+      '[indexer] Token registry update refused or failed',
+    );
+    throw err;
   }
 }
 

--- a/Makalu/indexer/src/token-registry.ts
+++ b/Makalu/indexer/src/token-registry.ts
@@ -1,0 +1,96 @@
+export interface SeedToken {
+  address: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  totalSupply: string;
+}
+
+export const MAKALU_EVM_CHAIN_ID = 700777;
+export const KAMET_EVM_CHAIN_ID = 900523;
+export const LITHO_MAINNET_EVM_CHAIN_ID = 9005;
+
+const MAKALU_TOKENS: readonly SeedToken[] = [
+  { address: '0x599a7E135f1790ae117b4EdDc0422D24Bc766161', name: 'Wrapped Lithosphere', symbol: 'wLITHO', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0xC4645CA5411D6E27556780AB4cdd0DF7e609df74', name: 'Lithosphere LitBTC', symbol: 'LitBTC', decimals: 18, totalSupply: '21000000000000000000000000' },
+  { address: '0x1Cde2Ca6c2ab8622003ebe06e382bC07850d4B8d', name: 'Lithosphere Algo', symbol: 'LAX', decimals: 18, totalSupply: '10000000000000000000000000000' },
+  { address: '0xEF2f35f6d0fb7DC9E87b8ca8252AE2E6ffb2a25e', name: 'Jot Art', symbol: 'JOT', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x10D4BB600c96e9243E2f50baFED8b2478F25af61', name: 'Colle AI', symbol: 'COLLE', decimals: 18, totalSupply: '5000000000000000000000000000' },
+  { address: '0xAcD98E323968647936887aD4934e64B01060727e', name: 'Imagen Network', symbol: 'IMAGE', decimals: 18, totalSupply: '10000000000000000000000000000' },
+  { address: '0x10052B8ccD2160b8F9880C6b4F5DD117fF253B1c', name: 'AGII', symbol: 'AGII', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x798eD6bFc5bfCFc60938d5098825b354427A0786', name: 'Built AI', symbol: 'BLDR', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0xDB829befCF8E582379E2c034FA2589b8D2EA1c5D', name: 'Mansa AI', symbol: 'MUSA', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x151ef362eA96853702Cc5e7728107e3961fbD22e', name: 'FurGPT', symbol: 'FGPT', decimals: 18, totalSupply: '1000000000000000000000000000' },
+];
+
+// Verified by read-only RPC calls against EVM chain 900523 on 2026-08-11.
+const KAMET_TOKENS: readonly SeedToken[] = [
+  { address: '0xC0FC628e3aB128fe387e7ed5e729bD809C017888', name: 'Wrapped Lithosphere', symbol: 'wLITHO', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x3A8D5FdC6c8dA9f14C535424b6F7206eC1996016', name: 'Lithosphere LitBTC', symbol: 'LitBTC', decimals: 18, totalSupply: '21000000000000000000000000' },
+  { address: '0xe8f504f9cE5391Fb5968b317f0b24b8A0306ACeb', name: 'Lithosphere Algo', symbol: 'LAX', decimals: 18, totalSupply: '10000000000000000000000000000' },
+  { address: '0x6AE14CEb3962664b13c5dEF29EB172De76bd0ac9', name: 'Jot Art', symbol: 'JOT', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x0573f66cb4bC34618e7AB8a941F7883DD2515dCA', name: 'Colle AI', symbol: 'COLLE', decimals: 18, totalSupply: '5000000000000000000000000000' },
+  { address: '0x8Ba6E3A0759144245f2939eB54164e32bb78B8E0', name: 'Imagen Network', symbol: 'IMAGE', decimals: 18, totalSupply: '10000000000000000000000000000' },
+  { address: '0x17D506aF1d0Dc2f4f64f15748a5aC46FAd3f06D7', name: 'AGII', symbol: 'AGII', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0xF05f1F79273874E554F02ce06585E16132a3B62B', name: 'Built AI', symbol: 'BLDR', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x2F366c6350A6b211f6D6F847c3D56738C2E847ca', name: 'FurGPT', symbol: 'FGPT', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x17A357262097B4e70acFfe8B71bC61e8bBcc3B42', name: 'Mansa AI', symbol: 'MUSA', decimals: 18, totalSupply: '1000000000000000000000000000' },
+  { address: '0x16EE7127C9E03e29ca5727e23dd7CB03D283cDBe', name: 'Quantts', symbol: 'QTT', decimals: 18, totalSupply: '1000000000000000000000000000' },
+];
+
+// Pre-reset and superseded Makalu addresses that must never be reintroduced by
+// static seeding. They remain cleanup candidates on every network.
+const LEGACY_STALE_TOKEN_ADDRESSES = [
+  '0xEB6cfcC84F35D6b20166cD6149Fed712ED2a7Cfe',
+  '0x468022F17CAFEBD43C18f68D53c66a1a7f0E5249',
+  '0x9611436ea7B4764Eeb1E31B83A5bF03c835Eb3e8',
+  '0x8187b232BDa461d17EA519Ba6898F7b220AAf2e2',
+  '0xE7eBf52bD714348984Fb00b4c99d9e994D60DF49',
+  '0x7a29252B13367800dD78FED47afFaB86a615c844',
+  '0x9984ad7a774218B263D74BD8A5FFEDa7DD6Fe020',
+  '0x07039884740F4DB0f71BD3bCF87a3FfA0B85A26F',
+  '0xa25c2a49893B0296977E2E70Da56AF47241d592F',
+  '0xDEE12eD9C5A1F7c29f3ab3961B892a8434A97EFa',
+  '0x93d74580a7b63a5B1FE5Aae05b7470bf9317aF9A',
+  '0xeC2B25393287025dbcdDb30659E689678c478337',
+  '0x0292C22AFC5DF714d51273BF16F9Fc3f17d97e7E',
+  '0xC0725568E86DCF6abE5729903bDF6FF999Ad52BD',
+  '0x25F70D427EB96b784ff2d0B458B6Aa5f6D251346',
+  '0xdB7b1F4b735e9f8096a44657599c9F6882ba0B0D',
+  '0xDB04AD818614a329110bdDA30c7c5e8C1Be61e45',
+  '0xb47B81370934Db2461759BD29796100fdD35e3E9',
+  '0x71ce67fCf5D130473F46DBaD05f3260A8390dE73',
+  '0x72791d72B6097D487cEC58605A62396c50C08b69',
+] as const;
+
+const REGISTRIES = new Map<number, readonly SeedToken[]>([
+  [MAKALU_EVM_CHAIN_ID, MAKALU_TOKENS],
+  [KAMET_EVM_CHAIN_ID, KAMET_TOKENS],
+  // Mainnet has no approved LAX or other LEP100 deployment yet. Keep this
+  // explicit so testnet addresses cannot leak into the production explorer.
+  [LITHO_MAINNET_EVM_CHAIN_ID, []],
+]);
+
+export function parseConfiguredEvmChainId(value: string | undefined): number {
+  const chainId = Number(value ?? MAKALU_EVM_CHAIN_ID);
+  if (!Number.isSafeInteger(chainId) || chainId <= 0) {
+    throw new Error('LITHO_CHAIN_ID must be a positive safe integer');
+  }
+  return chainId;
+}
+
+export function resolveSeededTokens(chainId: number): readonly SeedToken[] {
+  return REGISTRIES.get(chainId) ?? [];
+}
+
+export function resolveStaleTokenAddresses(chainId: number): string[] {
+  const active = new Set(resolveSeededTokens(chainId).map((token) => token.address.toLowerCase()));
+  const known = [
+    ...LEGACY_STALE_TOKEN_ADDRESSES,
+    ...MAKALU_TOKENS.map((token) => token.address),
+    ...KAMET_TOKENS.map((token) => token.address),
+  ];
+
+  return [...new Set(known.map((address) => address.toLowerCase()))]
+    .filter((address) => !active.has(address));
+}


### PR DESCRIPTION
## Summary

- stops the indexer from seeding Makalu LEP100 addresses into Kamet and LITHO mainnet databases
- selects independent registries for Makalu 700777 and Kamet 900523
- explicitly seeds no testnet tokens on mainnet 9005
- removes known foreign/static token rows and transfers during startup migration
- refuses registry mutation unless the EVM RPC reports the configured chain ID
- refuses to seed an address unless eth_getCode confirms deployed contract code

## LAX effect

- Makalu keeps LAX 