### PR TITLE
ci(makalu): publish and deploy faucet image

### DIFF
--- a/.github/workflows/deploy-simple.yaml
+++ b/.github/workflows/deploy-simple.yaml
@@ -7,20 +7,16 @@
 # LONGER in the public path, so its "green" never reached the live site.
 #
 # This pipeline deploys the published GHCR images to vps1 over SSH and gates on
-# the PUBLIC URL. It deliberately only `pull`s + `up -d`s the web/api services and
+# the PUBLIC URL. It deliberately only `pull`s + `up -d`s web/api/indexer/faucet and
 # NEVER overwrites vps1's hand-edited docker-compose.yml / .env, which carry the
 # "§4.4" hotfix wiring (drops the DB-hiding patch-live-chain-data/validators from
 # the api command, sets EXPLORER_INTERNAL_URL=http://web:3000, FORCE_REINDEX=0,
 # MAKALU_CHAIN_TIP_TOLERANCE=500). Overwriting them regresses the public site.
 # Full context: litho-validator-infra repo docs/MAKALU_STATE_AND_DEPLOY_HANDOFF.md
 #
-# ⚠️ INDEXER BLIND SPOT: the host ci-deploy.sh recreates ONLY web/api — the
-# indexer container keeps its old image across deploys. So an indexer-only code
-# change (e.g. a new src/mappings.ts migration) does NOT take effect here. Until
-# the host script is updated to also recreate the indexer, anything that must run
-# on deploy (DB migrations, index creation) belongs in the API startup, which IS
-# recreated — see Makalu/api/src/lib/ensure-indexes.ts. The image-wait below now
-# also waits for the indexer image so it is ready once the host script recreates it.
+# The protected host scripts are source-controlled at
+# Makalu/scripts/vps1-ci-{deploy,rollback}.sh. Install them atomically on vps1
+# before enabling a release that needs a newly added service.
 # ============================================================================
 name: Deploy Makalu Explorer (vps1)
 
@@ -36,6 +32,7 @@ on:
       - 'Makalu/api/**'
       - 'Makalu/indexer/**'
       - 'Makalu/explorer/**'
+      - 'Makalu/faucet/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -92,7 +89,8 @@ jobs:
           for i in $(seq 1 30); do
             if docker manifest inspect "$REGISTRY/lithosphere-explorer:$TAG" >/dev/null 2>&1 \
                && docker manifest inspect "$REGISTRY/lithosphere-api:$TAG" >/dev/null 2>&1 \
-               && docker manifest inspect "$REGISTRY/lithosphere-indexer:$TAG" >/dev/null 2>&1; then
+               && docker manifest inspect "$REGISTRY/lithosphere-indexer:$TAG" >/dev/null 2>&1 \
+               && docker manifest inspect "$REGISTRY/lithosphere-faucet:$TAG" >/dev/null 2>&1; then
               echo "images for $TAG are published"; exit 0
             fi
             echo "  [$i/30] waiting for $TAG ..."; sleep 20
@@ -110,8 +108,9 @@ jobs:
       # that runs ONLY /opt/lithoscan/ci/ci-deploy.sh on the literal arg `deploy`
       # (and ci-rollback.sh on `rollback`); any other command is rejected, plus
       # `restrict` (no pty/forwarding). So we just send `deploy` — the actual
-      # pull + `up -d` web/api logic (compose/.env preserved) lives in that host
-      # script. See litho-validator-infra docs/MAKALU_STATE_AND_DEPLOY_HANDOFF.md.
+      # pull + `up -d` web/api/indexer/faucet logic (compose/.env preserved) lives in that host
+      # script. See Makalu/scripts/vps1-ci-deploy.sh and the validator-infra
+      # MAKALU_STATE_AND_DEPLOY_HANDOFF.md.
       - name: Deploy to vps1 (pull + recreate, compose preserved)
         id: deploy
         run: |
@@ -128,8 +127,16 @@ jobs:
             sha=$(echo "$ver" | jq -r '.gitSha // "unknown"')
             nfts=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 "$PUBLIC_URL/nfts" 2>/dev/null || echo 000)
             summary=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 "$PUBLIC_URL/api/stats/summary" 2>/dev/null || echo 000)
-            echo "  [$i/18] /api/version gitSha=$sha  /nfts=$nfts  /api/stats/summary=$summary"
-            if [ "$sha" = "$expected" ] && [ "$nfts" = "200" ] && [ "$summary" = "200" ]; then ok=true; break; fi
+            faucet=$(curl -fsS --max-time 10 "$PUBLIC_URL/api/faucet/info" 2>/dev/null || echo '{}')
+            faucet_schema=$(echo "$faucet" | jq -r '
+              ((.ready | type) == "boolean") and
+              ((.unavailableAssetIds | type) == "array") and
+              ((.assets | type) == "array") and
+              (.assets | length > 0) and
+              ([.assets[] | has("available") and has("claimableAmounts") and has("minimumClaimAmount") and has("shortfall")] | all)
+            ' 2>/dev/null || echo false)
+            echo "  [$i/18] /api/version gitSha=$sha  /nfts=$nfts  /api/stats/summary=$summary  faucetSchema=$faucet_schema"
+            if [ "$sha" = "$expected" ] && [ "$nfts" = "200" ] && [ "$summary" = "200" ] && [ "$faucet_schema" = "true" ]; then ok=true; break; fi
             sleep 10
           done
           if [ "$ok" != true ]; then echo "::error::public health gate failed — makalu.litho.ai not serving $expected"; exit 1; fi
@@ -164,7 +171,7 @@ jobs:
           printf '%s\n' "${{ secrets.VPS1_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-      - name: Revert web + api to :previous
+      - name: Revert web + api + indexer + faucet to :previous
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes "$VPS_USER@$VPS_HOST" rollback
           echo "::warning::Makalu deploy rolled back to previous images"

--- a/.github/workflows/deploy-simple.yaml
+++ b/.github/workflows/deploy-simple.yaml
@@ -21,18 +21,16 @@
 name: Deploy Makalu Explorer (vps1)
 
 on:
-  # Trigger ONLY on image-producing changes — these are the exact paths that
-  # publish-images.yaml builds from. A workflow/doc-only change does NOT publish
-  # an image, so triggering a deploy on it would wait forever for a sha image
-  # that never gets built (and then needlessly roll back). Use workflow_dispatch
-  # to deploy a commit manually.
+  # Trigger automatically on the established explorer stack only. Faucet
+  # releases remain explicitly manual because they require an approved funded
+  # key, protected-host wrapper readiness, and a dedicated public health gate.
+  # Use workflow_dispatch to deploy a faucet release after those gates pass.
   push:
     branches: [main]
     paths:
       - 'Makalu/api/**'
       - 'Makalu/indexer/**'
       - 'Makalu/explorer/**'
-      - 'Makalu/faucet/**'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -120,9 +120,85 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      # Explorer requires NEXT_PUBLIC_* vars baked in at build time
-      - name: Build and Push — explorer (with mainnet build args)
+      # Build locally first so the CRITICAL gate runs before anything is pushed.
+      # Explorer requires NEXT_PUBLIC_* vars baked in at build time.
+      - name: Build security candidate — explorer
         id: build_explorer
+        if: matrix.service == 'explorer' && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          load: true
+          push: false
+          tags: lithosphere-${{ matrix.service }}:scan-${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=https://makalu.litho.ai/api
+            NEXT_PUBLIC_GRAPHQL_URL=https://makalu.litho.ai/api/graphql
+            NEXT_PUBLIC_RPC_URL=https://rpc.litho.ai
+            NEXT_PUBLIC_CHAIN_ID=700777
+            NEXT_PUBLIC_CHAIN_NAME=Lithosphere
+            NEXT_PUBLIC_SITE_URL=https://makalu.litho.ai
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_meta.outputs.build_time }}
+            VERSION=${{ steps.build_meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # API, Indexer and Faucet — build metadata only
+      - name: Build security candidate — ${{ matrix.service }}
+        id: build
+        if: matrix.service != 'explorer' && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          load: true
+          push: false
+          tags: lithosphere-${{ matrix.service }}:scan-${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_meta.outputs.build_time }}
+            VERSION=${{ steps.build_meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Trivy scan — HIGH/CRITICAL findings uploaded to GitHub Security tab for triage (non-blocking)
+      - name: Trivy scan (visibility — HIGH + CRITICAL to SARIF)
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: lithosphere-${{ matrix.service }}:scan-${{ github.sha }}
+          format: 'sarif'
+          output: 'trivy-${{ matrix.service }}.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always() && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service) && hashFiles(format('trivy-{0}.sarif', matrix.service)) != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-${{ matrix.service }}.sarif'
+          category: 'trivy-${{ matrix.service }}'
+
+      # Hard gate — fail the publish only on fixable CRITICAL CVEs
+      - name: Trivy gate (CRITICAL — blocks publish)
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: lithosphere-${{ matrix.service }}:scan-${{ github.sha }}
+          format: 'table'
+          severity: 'CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+
+      - name: Publish — explorer
+        id: publish_explorer
         if: matrix.service == 'explorer' && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
         uses: docker/build-push-action@v5
         with:
@@ -144,9 +220,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # API, Indexer and Faucet — build metadata only
-      - name: Build and Push — ${{ matrix.service }}
-        id: build
+      - name: Publish — ${{ matrix.service }}
+        id: publish
         if: matrix.service != 'explorer' && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
         uses: docker/build-push-action@v5
         with:
@@ -162,38 +237,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Trivy scan — HIGH/CRITICAL findings uploaded to GitHub Security tab for triage (non-blocking)
-      - name: Trivy scan (visibility — HIGH + CRITICAL to SARIF)
-        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ${{ matrix.image }}@${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
-          format: 'sarif'
-          output: 'trivy-${{ matrix.service }}.sarif'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-
-      - name: Upload Trivy SARIF to GitHub Security
-        if: always() && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service) && hashFiles(format('trivy-{0}.sarif', matrix.service)) != ''
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-${{ matrix.service }}.sarif'
-          category: 'trivy-${{ matrix.service }}'
-
-      # Hard gate — fail the publish only on fixable CRITICAL CVEs
-      - name: Trivy gate (CRITICAL — blocks publish)
-        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ${{ matrix.image }}@${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
-          format: 'table'
-          severity: 'CRITICAL'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-
       - name: Install Cosign
         if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: sigstore/cosign-installer@v3
@@ -201,7 +244,7 @@ jobs:
       - name: Sign image with Cosign (keyless)
         if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
+          IMAGE_DIGEST: ${{ steps.publish.outputs.digest || steps.publish_explorer.outputs.digest }}
         run: |
           if [ -n "$IMAGE_DIGEST" ]; then
             cosign sign --yes ${{ matrix.image }}@${IMAGE_DIGEST}
@@ -219,18 +262,18 @@ jobs:
       # Lifts the SLSA posture from "image is signed (Cosign keyless)" to
       # "image carries a verifiable build provenance" (SLSA build L2).
       - name: Generate SLSA build provenance attestation
-        if: (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service) && (steps.build.outputs.digest || steps.build_explorer.outputs.digest)
+        if: (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service) && (steps.publish.outputs.digest || steps.publish_explorer.outputs.digest)
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ matrix.image }}
-          subject-digest: ${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
+          subject-digest: ${{ steps.publish.outputs.digest || steps.publish_explorer.outputs.digest }}
           push-to-registry: true
 
       - name: Generate SBOM
         if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ matrix.image }}@${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
+          image: ${{ matrix.image }}@${{ steps.publish.outputs.digest || steps.publish_explorer.outputs.digest }}
           format: spdx-json
           output-file: sbom-${{ matrix.service }}.spdx.json
         continue-on-error: true
@@ -247,7 +290,7 @@ jobs:
       - name: Output image tags
         if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
+          IMAGE_DIGEST: ${{ steps.publish.outputs.digest || steps.publish_explorer.outputs.digest }}
         run: |
           echo "## Image Published: ${{ matrix.service }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,7 +1,7 @@
 # ============================================================================
 # Lithosphere — Build & Publish Docker Images to GHCR
-# Publishes: api, indexer, explorer
-# Registry:  ghcr.io/kajlabs/lithosphere-{api,indexer,explorer}
+# Publishes: api, indexer, explorer, faucet
+# Registry:  ghcr.io/kajlabs/lithosphere-{api,indexer,explorer,faucet}
 # Tags:      latest, mainnet, sha-<short>
 # ============================================================================
 
@@ -15,6 +15,7 @@ on:
       - 'Makalu/api/**'
       - 'Makalu/indexer/**'
       - 'Makalu/explorer/**'
+      - 'Makalu/faucet/**'
       - '.github/workflows/publish-images.yaml'
   workflow_dispatch:
     inputs:
@@ -23,9 +24,16 @@ on:
         required: false
         default: 'mainnet'
       service:
-        description: 'Service to build (api, indexer, explorer, all)'
+        description: 'Service to build (api, indexer, explorer, faucet, all)'
         required: false
         default: 'all'
+        type: choice
+        options:
+          - all
+          - api
+          - indexer
+          - explorer
+          - faucet
 
 env:
   # Opt every JavaScript-based action into Node.js 24 ahead of the
@@ -65,15 +73,22 @@ jobs:
             context: ./Makalu/explorer
             dockerfile: ./Makalu/explorer/Dockerfile
 
+          - service: faucet
+            image: ghcr.io/kajlabs/lithosphere-faucet
+            context: ./Makalu/faucet
+            dockerfile: ./Makalu/faucet/Dockerfile
+
     steps:
       - name: Checkout
-        if: github.event.inputs.service == 'all' || github.event.inputs.service == matrix.service || github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: docker/setup-buildx-action@v3
 
       - name: Compute build metadata
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         id: build_meta
         run: |
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -85,6 +100,7 @@ jobs:
           fi
 
       - name: Log in to GHCR
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -92,6 +108,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -106,7 +123,7 @@ jobs:
       # Explorer requires NEXT_PUBLIC_* vars baked in at build time
       - name: Build and Push — explorer (with mainnet build args)
         id: build_explorer
-        if: matrix.service == 'explorer'
+        if: matrix.service == 'explorer' && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
@@ -127,10 +144,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # API and Indexer — build metadata only
+      # API, Indexer and Faucet — build metadata only
       - name: Build and Push — ${{ matrix.service }}
         id: build
-        if: matrix.service != 'explorer'
+        if: matrix.service != 'explorer' && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
@@ -147,6 +164,7 @@ jobs:
 
       # Trivy scan — HIGH/CRITICAL findings uploaded to GitHub Security tab for triage (non-blocking)
       - name: Trivy scan (visibility — HIGH + CRITICAL to SARIF)
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ matrix.image }}@${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
@@ -158,7 +176,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Upload Trivy SARIF to GitHub Security
-        if: always() && hashFiles(format('trivy-{0}.sarif', matrix.service)) != ''
+        if: always() && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service) && hashFiles(format('trivy-{0}.sarif', matrix.service)) != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-${{ matrix.service }}.sarif'
@@ -166,6 +184,7 @@ jobs:
 
       # Hard gate — fail the publish only on fixable CRITICAL CVEs
       - name: Trivy gate (CRITICAL — blocks publish)
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ matrix.image }}@${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
@@ -176,9 +195,11 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Install Cosign
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: sigstore/cosign-installer@v3
 
       - name: Sign image with Cosign (keyless)
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
         run: |
@@ -198,7 +219,7 @@ jobs:
       # Lifts the SLSA posture from "image is signed (Cosign keyless)" to
       # "image carries a verifiable build provenance" (SLSA build L2).
       - name: Generate SLSA build provenance attestation
-        if: steps.build.outputs.digest || steps.build_explorer.outputs.digest
+        if: (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service) && (steps.build.outputs.digest || steps.build_explorer.outputs.digest)
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ matrix.image }}
@@ -206,6 +227,7 @@ jobs:
           push-to-registry: true
 
       - name: Generate SBOM
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         uses: anchore/sbom-action@v0
         with:
           image: ${{ matrix.image }}@${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
@@ -214,7 +236,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SBOM
-        if: always()
+        if: always() && (github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service)
         uses: actions/upload-artifact@v4
         with:
           name: sbom-${{ matrix.service }}
@@ -223,6 +245,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Output image tags
+        if: github.event_name == 'push' || inputs.service == 'all' || inputs.service == matrix.service
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest || steps.build_explorer.outputs.digest }}
         run: |

--- a/Makalu/faucet/Dockerfile
+++ b/Makalu/faucet/Dockerfile
@@ -16,6 +16,14 @@ RUN pnpm install --frozen-lockfile --prod || pnpm install --prod
 COPY --from=builder /app/dist dist/
 COPY frontend/ frontend/
 
+# The running faucet needs Node.js and its application dependencies only.
+# Removing npm/Corepack/pnpm eliminates build-time package-manager code from
+# the runtime attack surface (including npm's bundled node-tar).
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+       /usr/local/bin/pnpm /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+    && rm -rf /root/.cache /root/.local/share/pnpm /tmp/*
+
 EXPOSE 8081
 ENV NODE_ENV=production
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/Makalu/scripts/vps1-ci-deploy.sh
+++ b/Makalu/scripts/vps1-ci-deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+cd /opt/lithoscan
+
+image_services=(explorer api indexer faucet)
+compose_services=(web api indexer faucet)
+
+for service in "${image_services[@]}"; do
+  current_image=$(docker inspect --format '{{.Id}}' "ghcr.io/kajlabs/lithosphere-$service:mainnet" 2>/dev/null || true)
+  if [ -n "$current_image" ]; then
+    docker tag "$current_image" "ghcr.io/kajlabs/lithosphere-$service:previous"
+  fi
+done
+
+docker compose pull "${compose_services[@]}"
+docker compose up -d "${compose_services[@]}"
+
+docker ps --format '{{.Names}} {{.Status}} {{.Image}}' \
+  | grep -E 'lithoscan-(web|api|indexer|faucet)'

--- a/Makalu/scripts/vps1-ci-rollback.sh
+++ b/Makalu/scripts/vps1-ci-rollback.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+cd /opt/lithoscan
+
+image_services=(explorer api indexer faucet)
+compose_services=(web api indexer faucet)
+
+for service in "${image_services[@]}"; do
+  previous_image="ghcr.io/kajlabs/lithosphere-$service:previous"
+  if ! docker image inspect "$previous_image" >/dev/null 2>&1; then
+    echo "rollback aborted: missing $previous_image" >&2
+    exit 1
+  fi
+done
+
+for service in "${image_services[@]}"; do
+  docker tag \
+    "ghcr.io/kajlabs/lithosphere-$service:previous" \
+    "ghcr.io/kajlabs/lithosphere-$service:mainnet"
+done
+
+docker compose up -d --no-pull "${compose_services[@]}" 2>/dev/null \
+  || docker compose up -d "${compose_services[@]}"
+echo "rolled back web + api + indexer + faucet to :previous"


### PR DESCRIPTION
## Summary
- publish the Makalu faucet as `ghcr.io/kajlabs/lithosphere-faucet`
- wait for the immutable faucet SHA image before deployment
- deploy and roll back web, API, indexer, and faucet together via source-controlled protected-host scripts
- fail the public health gate unless `/api/faucet/info` exposes the MX-02 fail-closed availability schema
- make manual single-service image publishing work for the new faucet matrix entry

## Safety and rollout
- This workflow-only merge publishes images but does not trigger `deploy-simple.yaml`.
- Do not install the new protected-host scripts until the faucet image for the merged commit is published successfully.
- Install the scripts atomically at `/opt/lithoscan/ci/ci-deploy.sh` and `/opt/lithoscan/ci/ci-rollback.sh`, preserving backups and validating checksums/Bash syntax.
- Rotate the exposed faucet private key through the server secret path before deploying or funding the faucet.
- Then manually dispatch the gated deployment; retain automatic rollback and verify the public faucet schema.

## Validation
- `pnpm --dir Makalu/faucet test` — 7/7 passed
- `pnpm --dir Makalu/faucet build` — passed
- Actionlint 1.7.12 — passed
- ShellCheck 0.11.0 — passed
- YAML parsing, Bash syntax, `git diff --check` — passed

## Tracking
Follow-up status remains recorded in #81 / `docs/makalu-extra-works-handoff.md`.