### PR TITLE
fix(makalu): isolate core deploy from faucet gate

### DIFF
--- a/.github/workflows/deploy-simple.yaml
+++ b/.github/workflows/deploy-simple.yaml
@@ -7,7 +7,7 @@
 # LONGER in the public path, so its "green" never reached the live site.
 #
 # This pipeline deploys the published GHCR images to vps1 over SSH and gates on
-# the PUBLIC URL. It deliberately only `pull`s + `up -d`s web/api/indexer/faucet and
+# the PUBLIC URL. It deliberately only `pull`s + `up -d`s web/api/indexer and
 # NEVER overwrites vps1's hand-edited docker-compose.yml / .env, which carry the
 # "§4.4" hotfix wiring (drops the DB-hiding patch-live-chain-data/validators from
 # the api command, sets EXPLORER_INTERNAL_URL=http://web:3000, FORCE_REINDEX=0,
@@ -15,22 +15,24 @@
 # Full context: litho-validator-infra repo docs/MAKALU_STATE_AND_DEPLOY_HANDOFF.md
 #
 # The protected host scripts are source-controlled at
-# Makalu/scripts/vps1-ci-{deploy,rollback}.sh. Install them atomically on vps1
-# before enabling a release that needs a newly added service.
+# Makalu/scripts/vps1-ci-{deploy,rollback}.sh and intentionally operate only on
+# the explorer, API, and indexer. Faucet releases use a separate approval path.
 # ============================================================================
 name: Deploy Makalu Explorer (vps1)
 
 on:
   # Trigger automatically on the established explorer stack only. Faucet
-  # releases remain explicitly manual because they require an approved funded
+  # releases remain separate and manual because they require an approved funded
   # key, protected-host wrapper readiness, and a dedicated public health gate.
-  # Use workflow_dispatch to deploy a faucet release after those gates pass.
   push:
     branches: [main]
     paths:
       - 'Makalu/api/**'
       - 'Makalu/indexer/**'
       - 'Makalu/explorer/**'
+      - 'Makalu/scripts/vps1-ci-deploy.sh'
+      - 'Makalu/scripts/vps1-ci-rollback.sh'
+      - '.github/workflows/deploy-simple.yaml'
   workflow_dispatch:
     inputs:
       environment:
@@ -87,8 +89,7 @@ jobs:
           for i in $(seq 1 30); do
             if docker manifest inspect "$REGISTRY/lithosphere-explorer:$TAG" >/dev/null 2>&1 \
                && docker manifest inspect "$REGISTRY/lithosphere-api:$TAG" >/dev/null 2>&1 \
-               && docker manifest inspect "$REGISTRY/lithosphere-indexer:$TAG" >/dev/null 2>&1 \
-               && docker manifest inspect "$REGISTRY/lithosphere-faucet:$TAG" >/dev/null 2>&1; then
+               && docker manifest inspect "$REGISTRY/lithosphere-indexer:$TAG" >/dev/null 2>&1; then
               echo "images for $TAG are published"; exit 0
             fi
             echo "  [$i/30] waiting for $TAG ..."; sleep 20
@@ -106,7 +107,7 @@ jobs:
       # that runs ONLY /opt/lithoscan/ci/ci-deploy.sh on the literal arg `deploy`
       # (and ci-rollback.sh on `rollback`); any other command is rejected, plus
       # `restrict` (no pty/forwarding). So we just send `deploy` — the actual
-      # pull + `up -d` web/api/indexer/faucet logic (compose/.env preserved) lives in that host
+      # pull + `up -d` web/api/indexer logic (compose/.env preserved) lives in that host
       # script. See Makalu/scripts/vps1-ci-deploy.sh and the validator-infra
       # MAKALU_STATE_AND_DEPLOY_HANDOFF.md.
       - name: Deploy to vps1 (pull + recreate, compose preserved)
@@ -125,16 +126,8 @@ jobs:
             sha=$(echo "$ver" | jq -r '.gitSha // "unknown"')
             nfts=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 "$PUBLIC_URL/nfts" 2>/dev/null || echo 000)
             summary=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 "$PUBLIC_URL/api/stats/summary" 2>/dev/null || echo 000)
-            faucet=$(curl -fsS --max-time 10 "$PUBLIC_URL/api/faucet/info" 2>/dev/null || echo '{}')
-            faucet_schema=$(echo "$faucet" | jq -r '
-              ((.ready | type) == "boolean") and
-              ((.unavailableAssetIds | type) == "array") and
-              ((.assets | type) == "array") and
-              (.assets | length > 0) and
-              ([.assets[] | has("available") and has("claimableAmounts") and has("minimumClaimAmount") and has("shortfall")] | all)
-            ' 2>/dev/null || echo false)
-            echo "  [$i/18] /api/version gitSha=$sha  /nfts=$nfts  /api/stats/summary=$summary  faucetSchema=$faucet_schema"
-            if [ "$sha" = "$expected" ] && [ "$nfts" = "200" ] && [ "$summary" = "200" ] && [ "$faucet_schema" = "true" ]; then ok=true; break; fi
+            echo "  [$i/18] /api/version gitSha=$sha  /nfts=$nfts  /api/stats/summary=$summary"
+            if [ "$sha" = "$expected" ] && [ "$nfts" = "200" ] && [ "$summary" = "200" ]; then ok=true; break; fi
             sleep 10
           done
           if [ "$ok" != true ]; then echo "::error::public health gate failed — makalu.litho.ai not serving $expected"; exit 1; fi
@@ -169,7 +162,7 @@ jobs:
           printf '%s\n' "${{ secrets.VPS1_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-      - name: Revert web + api + indexer + faucet to :previous
+      - name: Revert web + api + indexer to :previous
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=yes "$VPS_USER@$VPS_HOST" rollback
           echo "::warning::Makalu deploy rolled back to previous images"

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -16,6 +16,9 @@ on:
       - 'Makalu/indexer/**'
       - 'Makalu/explorer/**'
       - 'Makalu/faucet/**'
+      - 'Makalu/scripts/vps1-ci-deploy.sh'
+      - 'Makalu/scripts/vps1-ci-rollback.sh'
+      - '.github/workflows/deploy-simple.yaml'
       - '.github/workflows/publish-images.yaml'
   workflow_dispatch:
     inputs:

--- a/Makalu/scripts/vps1-ci-deploy.sh
+++ b/Makalu/scripts/vps1-ci-deploy.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 cd /opt/lithoscan
 
-image_services=(explorer api indexer faucet)
-compose_services=(web api indexer faucet)
+image_services=(explorer api indexer)
+compose_services=(web api indexer)
 
 for service in "${image_services[@]}"; do
   current_image=$(docker inspect --format '{{.Id}}' "ghcr.io/kajlabs/lithosphere-$service:mainnet" 2>/dev/null || true)
@@ -17,4 +17,4 @@ docker compose pull "${compose_services[@]}"
 docker compose up -d "${compose_services[@]}"
 
 docker ps --format '{{.Names}} {{.Status}} {{.Image}}' \
-  | grep -E 'lithoscan-(web|api|indexer|faucet)'
+  | grep -E 'lithoscan-(web|api|indexer)'

--- a/Makalu/scripts/vps1-ci-rollback.sh
+++ b/Makalu/scripts/vps1-ci-rollback.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 cd /opt/lithoscan
 
-image_services=(explorer api indexer faucet)
-compose_services=(web api indexer faucet)
+image_services=(explorer api indexer)
+compose_services=(web api indexer)
 
 for service in "${image_services[@]}"; do
   previous_image="ghcr.io/kajlabs/lithosphere-$service:previous"
@@ -22,4 +22,4 @@ done
 
 docker compose up -d --no-pull "${compose_services[@]}" 2>/dev/null \
   || docker compose up -d "${compose_services[@]}"
-echo "rolled back web + api + indexer + faucet to :previous"
+echo "rolled back web + api + indexer to :previous"

--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -1,10 +1,10 @@
 # Makalu extra works — living handoff
 
 - **Status:** Active — closing one stream at a time
-- **Last verified:** 2026-08-14 21:27 PKT (UTC+05:00)
+- **Last verified:** 2026-08-14 21:45 PKT (UTC+05:00)
 - **Repository:** `KaJLabs/Lithosphere`
-- **Default branch inspected:** `origin/main` at `ae9bf1f341e26e8ed4cbdcb44cd5e8f3e3602f5e`
-- **Latest merged closure:** PR #82 at `f6303f9d39f3c8075284dc73ecb65d4b3556e7eb`
+- **Default branch inspected:** `origin/main` at `6ded419ca7034f9ded110255dd1a2683d3399029`
+- **Latest merged closure:** PR #83 at `6ded419ca7034f9ded110255dd1a2683d3399029`
 - **Network in scope:** Makalu testnet, EVM chain ID `700777`, Cosmos chain ID `lithosphere_700777-2`
 
 This is the source of truth for the seven Makalu extra-work streams. Update it whenever code is merged, a release is
@@ -47,7 +47,7 @@ into a reviewable change, and never bulk-commit the dirty worktree.
 | --- | --- | --- | --- | --- |
 | MX-06 | Validator cleanup and safety | Chain monitor active; encrypted backup blocked | EXTERNAL BLOCKER | Assign custodians and add the public `BACKUP_RECIPIENT`, then run backup/restore verification. |
 | MX-02 | LEP100 faucet assets | Safeguards and secured image pipeline merged; production release remains manual | EXTERNAL BLOCKER | Rotate the exposed faucet key, install the protected wrapper, fund assets, deploy, and prove live claims/alerts. |
-| MX-03 | Thanos Wallet | Integration verified; acceptance open | IN PROGRESS | Complete the published-version browser matrix and one approved signed-transaction test. |
+| MX-03 | Thanos Wallet | Repository work merged; deployment rolled back safely | IN PROGRESS | Decouple the core deploy gate from the paused faucet, redeploy, then obtain wallet-team acceptance. |
 | MX-04 | DNNS | Merged and deployed; live-name acceptance open | EXTERNAL BLOCKER | Obtain two stable test names and DNNS interface/cache confirmation. |
 | MX-05 | Quantt | Adapter deployed but deliberately unconfigured | EXTERNAL BLOCKER | Obtain API contract/credential and repair or replace the development TLS endpoint. |
 | MX-01 | MultX / Lithoswap | Candidate source merged; Makalu swap disabled | IN PROGRESS | Resolve open DEX PRs, audit, deploy, seed approved liquidity, and run live acceptance. |
@@ -130,8 +130,8 @@ Evidence:
 asset is below its minimum ten-token claim: WLITHO, LITBTC, JOT, COLLE, and FGPT have zero; LAX, IMAGE, AGII, BLDR,
 and MUSA have five. Balance-aware, fail-closed API and explorer behavior passed seven focused tests plus a strict
 TypeScript build. PR #80 merged those safeguards on 2026-08-14. PR #82 then merged secured faucet image publishing,
-pre-publication vulnerability gating, immutable image waiting, a public faucet-schema gate, and source-controlled
-deploy/rollback wrappers as `f6303f9d39f3c8075284dc73ecb65d4b3556e7eb`. The merged faucet image passed Trivy,
+pre-publication vulnerability gating, immutable image waiting, and source-controlled deploy/rollback candidates as
+`f6303f9d39f3c8075284dc73ecb65d4b3556e7eb`. The merged faucet image passed Trivy,
 signing, provenance, and SBOM generation at digest
 `sha256:34391877a9029461dfc261ce1ed0704b791d19f9065c0367a297952e49be12d8`. Production was intentionally not
 deployed: faucet releases are manual pending rotation of the exposed funding key and protected-wrapper activation.
@@ -159,8 +159,8 @@ Remaining actions:
 - [ ] Rotate the exposed faucet funding key through the server secret-management path before deployment; do not
       transmit the replacement key through chat or repository files.
 - [ ] Have the VPS owner update the restricted deploy and rollback wrappers to recreate/restore the faucet container.
-- [x] Extend the manual Makalu release workflow's immutable image wait and public health gate to cover the faucet
-      image and new availability fields; keep faucet releases manual until the funding/wrapper gates pass.
+- [ ] Add and activate a separate manual faucet release workflow with immutable image, schema, and rollback gates
+      after the funding key is rotated and the dedicated restricted wrappers are installed.
 - [ ] Deploy the faucet/API/explorer release and verify unavailable assets are clearly disabled.
 - [ ] Obtain approved replenishment amounts and fund every token above its operational reserve threshold.
 - [ ] Execute one live claim for every asset and retain transaction hashes.
@@ -201,8 +201,11 @@ Evidence:
 **Current state:** Thanos is integrated as the EIP-6963 injected provider `fi.thanos.wallet`, with the extension's
 official `window.thanos` surface as a fallback. Direct discovery, network addition/switching, SIWE message signing,
 signature normalization, nonce verification, replay protection, bearer sessions, and disconnect behavior are
-implemented. The published Chrome version and production secret gate are verified. Wallet-team browser acceptance
-and a low-value signed transaction remain open.
+implemented. PR #83 merged the discovery hardening and acceptance record as
+`6ded419ca7034f9ded110255dd1a2683d3399029`. The published Chrome version and production secret gate are verified.
+Its first deployment was rolled back safely because the core explorer health gate incorrectly required the paused
+MX-02 faucet schema. Core-gate correction, redeployment, wallet-team browser acceptance, and a low-value signed
+transaction remain open.
 
 Completed or evidenced:
 
@@ -216,9 +219,12 @@ Completed or evidenced:
 - [x] The production Makalu API uses a present, non-placeholder `AUTH_SESSION_SECRET` of at least 32 characters;
       the value was not exposed (2026-08-14).
 - [x] Automated coverage includes late EIP-6963 announcement and the official `window.thanos` fallback.
+- [x] PR #83 passed all 15 required/reporting checks and merged as `6ded419ca7034f9ded110255dd1a2683d3399029`.
 
 Remaining actions:
 
+- [ ] Correct the core deployment gate so it does not deploy or require the separately paused faucet, then redeploy
+      and verify the live release SHA.
 - [ ] Wallet team tests published extension version `0.9.33` in Chrome/Chromium and records browser/version evidence.
 - [ ] Test fresh install, late EIP-6963 announcement, user rejection, wrong chain, network switch, reconnect, sign-out,
       extension restart, and browser restart.
@@ -241,6 +247,8 @@ Evidence:
 - `Makalu/explorer/test/auth.test.ts`
 - `Makalu/explorer/test/walletNetwork.test.ts`
 - `docs/thanos-wallet-acceptance.md`
+- `https://github.com/KaJLabs/Lithosphere/pull/83`
+- `https://github.com/KaJLabs/Lithosphere/actions/runs/31819790372`
 
 ## MX-04 — DNNS integration
 
@@ -503,12 +511,22 @@ Evidence:
 | 2026-08-14 | Thanos published release | PASS | Chrome Web Store reports `0.9.33`; matching source commit `c352a5cfef22` confirms EIP-6963, `fi.thanos.wallet`, `window.thanos`, and signing support. |
 | 2026-08-14 | Thanos production auth | PASS | Makalu API secret checked value-free: present, non-placeholder, and at least 32 characters. `/signin` 200, nonce 200 with valid format, unauthenticated `/api/auth/me` 401. |
 | 2026-08-14 | Thanos repository verification | PASS | API: 6 focused tests and TypeScript build passed. Explorer: all 128 tests passed; Next compilation/type validation passed before Windows denied standalone symlink creation. |
+| 2026-08-14 | Thanos merge | PASS | PR #83 passed all 15 checks and merged as `6ded419ca7034f9ded110255dd1a2683d3399029`. |
+| 2026-08-14 | Thanos deployment | ROLLED BACK | Run `31819790372` served the correct release SHA and passed core routes, but an incorrectly coupled faucet-schema condition failed; automatic rollback passed and restored the prior healthy release. |
 | 2026-08-14 | DNNS registry | PASS | Kamet chain ID 900523; configured registry address contains contract bytecode. |
 | 2026-08-14 | Quantt | BLOCKED | Live adapter reports `configured: false`; development hostname fails TLS validation. |
 | 2026-08-14 | Mainnet chain monitor | PASS | Three latest inspected protected runs passed. |
 | 2026-08-14 | Signing-state backup | BLOCKED | Scheduled workflow fails closed because `BACKUP_RECIPIENT` is empty. |
 
 ## Change log
+
+### 2026-08-14 — MX-03 merged; core deployment gate correction opened
+
+- PR #83 passed all checks and merged as `6ded419ca7034f9ded110255dd1a2683d3399029`.
+- Deployment run `31819790372` served the new release and passed the explorer routes, but the core workflow also
+  required the intentionally undeployed MX-02 faucet schema. The gate failed and automatic rollback succeeded.
+- Verified the protected host scripts deploy only explorer, API, and indexer. Updated the repository copies and CI
+  gate to match that isolation; the faucet remains untouched pending its separate approval path.
 
 ### 2026-08-14 — MX-03 repository verification and wallet-team handoff
 


### PR DESCRIPTION
## Incident
MX-03 merge deployment run `31819790372` served the expected release SHA and passed the core explorer routes, but failed because the core health gate required the deliberately undeployed MX-02 faucet schema. Automatic rollback succeeded.

## Fix
- keep the automatic deploy and rollback strictly scoped to explorer/API/indexer
- remove faucet image/schema coupling from the core wait and public-health gate
- align source-controlled wrappers with the verified live protected wrappers
- trigger image publication when core deploy workflow/wrappers change
- record the failed deployment and rollback in the living handoff

The faucet remains untouched and requires its own manual workflow after key rotation, funding approval, and dedicated wrapper activation.

## Verification
- inspected failed run logs and confirmed every sample served the expected release SHA after warm-up
- confirmed rollback job passed and public Makalu serves the prior healthy release
- verified live protected wrappers operate only on explorer/API/indexer
- `bash -n` passed for both source-controlled wrapper scripts
- `git diff --check` passed
- workflow files parse successfully through Prettier