### PR TITLE
fix(makalu): harden DNNS resolution

### DIFF
--- a/Makalu/explorer/components/DnnsName.tsx
+++ b/Makalu/explorer/components/DnnsName.tsx
@@ -12,9 +12,13 @@ export default function DnnsName({ address }: { address?: string | null }) {
     setName(null);
     if (!address || !isAddress(address)) return () => { cancelled = true; };
 
-    void lookupAddress(address).then((resolved) => {
-      if (!cancelled) setName(resolved);
-    });
+    void lookupAddress(address)
+      .then((resolved) => {
+        if (!cancelled) setName(resolved);
+      })
+      .catch(() => {
+        if (!cancelled) setName(null);
+      });
     return () => { cancelled = true; };
   }, [address]);
 

--- a/Makalu/explorer/components/SearchBar.tsx
+++ b/Makalu/explorer/components/SearchBar.tsx
@@ -17,7 +17,11 @@ export default function SearchBar() {
     if (!q) return;
 
     // DNNS name (e.g. alice.litho) → resolve to an address on Kamet, then route.
-    if (isDnnsName(q)) {
+    if (q.toLowerCase().endsWith('.litho')) {
+      if (!isDnnsName(q)) {
+        setError('Invalid .litho name. Use one label of at least 3 letters, numbers, or hyphens.');
+        return;
+      }
       setResolving(true);
       try {
         const addr = await resolveName(q);

--- a/Makalu/explorer/lib/dnns.ts
+++ b/Makalu/explorer/lib/dnns.ts
@@ -49,23 +49,30 @@ export function namehash(name: string): string {
 /** True if `input` looks like a `.litho` DNNS name. */
 export function isDnnsName(input: string): boolean {
   const v = input.trim().toLowerCase();
-  return v.endsWith(`.${DNNS.tld}`) && v.length > DNNS.tld.length + 1;
+  return v.endsWith(`.${DNNS.tld}`) && normalizeDnnsName(v) !== null;
 }
 
-function fullName(input: string): string {
+/** Normalize the supported v0 2LD format, or return null when malformed. */
+export function normalizeDnnsName(input: string): string | null {
   const v = input.trim().toLowerCase();
-  return v.endsWith(`.${DNNS.tld}`) ? v : `${v}.${DNNS.tld}`;
+  const suffix = `.${DNNS.tld}`;
+  const label = v.endsWith(suffix) ? v.slice(0, -suffix.length) : v;
+  if (label.length < 3 || !/^[a-z0-9-]+$/.test(label)) return null;
+  if (label.startsWith('-') || label.endsWith('-')) return null;
+  return `${label}${suffix}`;
 }
 
-const forwardCache = new Map<string, string | null>();
-const reverseCache = new Map<string, string | null>();
+export class DnnsResolutionError extends Error {
+  constructor(direction: 'forward' | 'reverse', options?: ErrorOptions) {
+    super(`DNNS ${direction} resolution is unavailable`, options);
+    this.name = 'DnnsResolutionError';
+  }
+}
 
 /** Resolve a `.litho` name to an EVM address, or null if unregistered/unset. */
 export async function resolveName(input: string): Promise<string | null> {
-  const name = fullName(input);
-  if (forwardCache.has(name)) return forwardCache.get(name) ?? null;
-
-  let result: string | null = null;
+  const name = normalizeDnnsName(input);
+  if (!name) return null;
   try {
     const node = namehash(name);
     const registry = new Contract(DNNS.registry, REGISTRY_ABI, provider());
@@ -73,22 +80,18 @@ export async function resolveName(input: string): Promise<string | null> {
     if (resolverAddr && resolverAddr !== ZeroAddress) {
       const resolver = new Contract(resolverAddr, RESOLVER_ABI, provider());
       const addr: string = await resolver.addr(node);
-      if (addr && addr !== ZeroAddress) result = getAddress(addr);
+      if (addr && addr !== ZeroAddress) return getAddress(addr);
     }
-  } catch {
-    result = null;
+    return null;
+  } catch (cause) {
+    throw new DnnsResolutionError('forward', { cause });
   }
-  forwardCache.set(name, result);
-  return result;
 }
 
 /** Reverse-resolve an EVM address to its primary `.litho` name, or null. */
 export async function lookupAddress(address: string): Promise<string | null> {
   if (!isAddress(address)) return null;
   const key = address.toLowerCase();
-  if (reverseCache.has(key)) return reverseCache.get(key) ?? null;
-
-  let result: string | null = null;
   try {
     const reverseNode = namehash(`${key.slice(2)}.addr.reverse`);
     const registry = new Contract(DNNS.registry, REGISTRY_ABI, provider());
@@ -96,11 +99,17 @@ export async function lookupAddress(address: string): Promise<string | null> {
     if (resolverAddr && resolverAddr !== ZeroAddress) {
       const resolver = new Contract(resolverAddr, RESOLVER_ABI, provider());
       const name: string = await resolver.name(reverseNode);
-      if (name) result = name;
+      if (!name || !isDnnsName(name)) return null;
+
+      // A reverse resolver is not authoritative by itself. Confirm that the
+      // returned name resolves back to the address before displaying it.
+      const normalizedName = normalizeDnnsName(name);
+      if (!normalizedName) return null;
+      const forwardAddress = await resolveName(normalizedName);
+      if (forwardAddress?.toLowerCase() === key) return normalizedName;
     }
-  } catch {
-    result = null;
+    return null;
+  } catch (cause) {
+    throw new DnnsResolutionError('reverse', { cause });
   }
-  reverseCache.set(key, result);
-  return result;
 }

--- a/Makalu/explorer/test/dnns-resolver.test.ts
+++ b/Makalu/explorer/test/dnns-resolver.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const contract = vi.hoisted(() => ({
+  resolver: vi.fn(),
+  addr: vi.fn(),
+  name: vi.fn(),
+}));
+
+vi.mock('ethers', async (importOriginal) => {
+  const original = await importOriginal<typeof import('ethers')>();
+
+  class MockJsonRpcProvider {}
+  class MockContract {
+    resolver = contract.resolver;
+    addr = contract.addr;
+    name = contract.name;
+  }
+
+  return {
+    ...original,
+    Contract: MockContract,
+    JsonRpcProvider: MockJsonRpcProvider,
+  };
+});
+
+import {
+  DnnsResolutionError,
+  lookupAddress,
+  resolveName,
+} from '@/lib/dnns';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const RESOLVER_ADDRESS = '0xc0F0849e09Df12E54fe4345ab4535B1F521f2190';
+const OWNER_ADDRESS = '0xE9267bDf7084815B0754545049AE45FE744Aefa8';
+
+beforeEach(() => {
+  contract.resolver.mockReset();
+  contract.addr.mockReset();
+  contract.name.mockReset();
+});
+
+describe('DNNS resolver safety', () => {
+  it('returns a checksummed forward address and null for an unset name', async () => {
+    contract.resolver.mockResolvedValueOnce(RESOLVER_ADDRESS);
+    contract.addr.mockResolvedValueOnce(OWNER_ADDRESS.toLowerCase());
+    await expect(resolveName(' Makalu.LITHO ')).resolves.toBe(OWNER_ADDRESS);
+
+    contract.resolver.mockResolvedValueOnce(ZERO_ADDRESS);
+    await expect(resolveName('missing.litho')).resolves.toBeNull();
+  });
+
+  it('does not retain a process-lifetime negative result', async () => {
+    contract.resolver
+      .mockResolvedValueOnce(ZERO_ADDRESS)
+      .mockResolvedValueOnce(RESOLVER_ADDRESS);
+    contract.addr.mockResolvedValueOnce(OWNER_ADDRESS);
+
+    await expect(resolveName('new-record.litho')).resolves.toBeNull();
+    await expect(resolveName('new-record.litho')).resolves.toBe(OWNER_ADDRESS);
+  });
+
+  it('distinguishes an RPC failure from an unset name', async () => {
+    contract.resolver.mockRejectedValueOnce(new Error('RPC unavailable'));
+    await expect(resolveName('makalu.litho')).rejects.toBeInstanceOf(DnnsResolutionError);
+  });
+
+  it('accepts a reverse name only when it resolves back to the address', async () => {
+    contract.resolver.mockResolvedValue(RESOLVER_ADDRESS);
+    contract.name.mockResolvedValueOnce('Makalu.LITHO');
+    contract.addr.mockResolvedValueOnce(OWNER_ADDRESS);
+
+    await expect(lookupAddress(OWNER_ADDRESS)).resolves.toBe('makalu.litho');
+  });
+
+  it('rejects an unverified or out-of-scope reverse name', async () => {
+    contract.resolver.mockResolvedValue(RESOLVER_ADDRESS);
+    contract.name
+      .mockResolvedValueOnce('makalu.litho')
+      .mockResolvedValueOnce('example.eth');
+    contract.addr.mockResolvedValueOnce('0x1111111111111111111111111111111111111111');
+
+    await expect(lookupAddress(OWNER_ADDRESS)).resolves.toBeNull();
+    await expect(lookupAddress(OWNER_ADDRESS)).resolves.toBeNull();
+  });
+});

--- a/Makalu/explorer/test/dnns.test.tsx
+++ b/Makalu/explorer/test/dnns.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/lib/dnns', async (importOriginal) => {
 
 import DnnsName from '@/components/DnnsName';
 import SearchBar from '@/components/SearchBar';
-import { isDnnsName, namehash } from '@/lib/dnns';
+import { isDnnsName, namehash, normalizeDnnsName } from '@/lib/dnns';
 
 beforeEach(() => {
   push.mockReset();
@@ -27,6 +27,10 @@ describe('DNNS integration', () => {
   it('recognizes .litho names case-insensitively and hashes deterministically', () => {
     expect(isDnnsName('Alice.LITHO')).toBe(true);
     expect(isDnnsName('alice.eth')).toBe(false);
+    expect(isDnnsName('ab.litho')).toBe(false);
+    expect(isDnnsName('sub.alice.litho')).toBe(false);
+    expect(isDnnsName('-alice.litho')).toBe(false);
+    expect(normalizeDnnsName(' Alice.LITHO ')).toBe('alice.litho');
     expect(namehash('alice.litho')).toMatch(/^0x[0-9a-f]{64}$/);
     expect(namehash('alice.litho')).toBe(namehash('alice.litho'));
   });
@@ -52,6 +56,17 @@ describe('DNNS integration', () => {
     });
     fireEvent.submit(screen.getByRole('button', { name: 'Search' }).closest('form')!);
     expect(await screen.findByText(/No address is set for missing\.litho/)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed .litho name without querying or navigating', async () => {
+    render(<SearchBar />);
+    fireEvent.change(screen.getByPlaceholderText(/block, tx, address/i), {
+      target: { value: 'sub.alice.litho' },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: 'Search' }).closest('form')!);
+    expect(await screen.findByText(/Invalid \.litho name/)).toBeInTheDocument();
+    expect(resolveName).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
   });
 

--- a/docs/dnns-acceptance.md
+++ b/docs/dnns-acceptance.md
@@ -1,0 +1,104 @@
+# DNNS explorer acceptance record
+
+- **Workstream:** MX-04
+- **Environment:** Makalu explorer reading the Kamet DNNS registry
+- **Status:** Repository verification in progress; DNNS-team acceptance pending
+- **Last verified:** 2026-08-14
+
+This record separates facts verified from deployed contracts and source-controlled deployment metadata from items
+that still require the DNNS owner's confirmation. It must not be marked accepted until every open item below has a
+named approver and evidence.
+
+## Verified deployed v0 baseline
+
+The deployed v0 source of truth is `contracts/dnns/` at
+`KaJLabs/lithosphere-dev-infra@b6669f2aca38f3cb8680e8086920d244c260eeae`. The Makalu explorer performs
+read-only resolution against that Kamet deployment because the same EVM address can be used across Lithosphere
+chains.
+
+| Field | Verified value |
+| --- | --- |
+| Network | Kamet |
+| EVM chain ID | `900523` |
+| RPC | `https://rpc-3.litho.ai` |
+| TLD | `.litho` |
+| Supported name form | One second-level label only (2LD) |
+| Registry | `0x316dc15bF377F7187e5BE38BA19e673Ca823d1ab` |
+| Base registrar | `0xB3D1a8e92FFAD73Ab8a07BF37A8E1374df8B3722` |
+| Controller | `0xb042145B0Fd44b53691b59E98bE8F9F9EB0365c5` |
+| Original resolver | `0xc0F0849e09Df12E54fe4345ab4535B1F521f2190` |
+| Wrapper-aware resolver | `0x54639d978418766ccaD25ffb22C58fd5A5Df8C09` |
+| Reverse registrar | `0xDeFae50866342C8f72bd03292FFeAeb53eC781C2` |
+| Reverse default resolver | Not configured in the latest deployment record |
+
+The deployed portal rules normalize labels to lowercase and require at least three characters, using only
+`a-z`, `0-9`, and internal hyphens. Leading/trailing hyphens and subdomains are rejected. The explorer now applies
+the same rules before making an RPC request.
+
+## Live forward-resolution evidence
+
+On 2026-08-14, direct read-only JSON-RPC probes confirmed chain ID `900523`, bytecode at the registry address, and
+the following registry/resolver results. Each name currently resolves to
+`0xE9267bDf7084815B0754545049AE45FE744Aefa8` through its registry-selected resolver:
+
+| Name | Result |
+| --- | --- |
+| `litho.litho` | PASS |
+| `kamet.litho` | PASS |
+| `makalu.litho` | PASS |
+| `dex.litho` | PASS |
+| `treasury.litho` | PASS |
+| `team.litho` | PASS |
+| `faucet.litho` | PASS |
+| `quantts.litho` | PASS |
+| `bridge.litho` | PASS |
+
+These records provide more than the two stable forward fixtures required by the acceptance gate. They do not prove
+reverse resolution: the reverse node for the shared address currently has no resolver.
+
+## Explorer behavior and automated gates
+
+- [x] Forward results are checksummed before navigation.
+- [x] An unset name returns "not found" while an RPC/provider failure is reported as unavailable.
+- [x] Negative results are not cached for the life of the explorer process.
+- [x] Malformed `.litho` names are rejected before RPC access.
+- [x] Reverse names are displayed only after the name resolves forward to the queried address.
+- [x] Components handle reverse-provider failures without an unhandled promise rejection.
+- [ ] Record the merged PR, deployment run, and live explorer release below.
+
+## Documentation/interface discrepancy
+
+The public [DNNS documentation](https://dnns.litho.ai/) links to
+[KaJLabs/DNNS](https://github.com/KaJLabs/DNNS) and describes a newer Makalu-oriented reference architecture. It
+does not publish the deployed v0 contract addresses and its network details do not match the Kamet v0 deployment
+used by the explorer. The DNNS owner must choose one of these outcomes:
+
+1. Confirm the Kamet v0 deployment above remains the supported explorer resolution interface and update the public
+   documentation accordingly; or
+2. Provide the reviewed Makalu registry/resolver deployment metadata and migration date, after which the explorer
+   configuration and tests must be updated before acceptance.
+
+No network or contract migration should be inferred from documentation alone.
+
+## Remaining owner acceptance
+
+- [ ] DNNS owner confirms which deployed interface is supported for the Makalu explorer.
+- [ ] DNNS owner corrects/publishes authoritative network IDs, contract addresses, normalization, and reverse rules.
+- [ ] DNNS owner configures or nominates one stable reverse record and supplies its expected name/address pair.
+- [ ] Dev Infra repeats live forward, missing-name, malformed-name, RPC-failure, and forward-verified reverse tests
+      against the deployed explorer release.
+- [ ] DNNS owner approves the no-persistent-cache policy or supplies bounded positive/negative TTL requirements.
+- [ ] DNNS owner signs the acceptance fields below.
+
+## Evidence and approval
+
+| Field | Value |
+| --- | --- |
+| Explorer PR | Pending |
+| Merge commit | Pending |
+| Deployment workflow/run | Pending |
+| Deployed release | Pending |
+| Live smoke-test artifact | Pending |
+| DNNS approver | Pending |
+| Approval date | Pending |
+| Approval evidence | Pending |

--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -48,7 +48,7 @@ into a reviewable change, and never bulk-commit the dirty worktree.
 | MX-06 | Validator cleanup and safety | Chain monitor active; encrypted backup blocked | EXTERNAL BLOCKER | Assign custodians and add the public `BACKUP_RECIPIENT`, then run backup/restore verification. |
 | MX-02 | LEP100 faucet assets | Safeguards and secured image pipeline merged; production release remains manual | EXTERNAL BLOCKER | Rotate the exposed faucet key, install the protected wrapper, fund assets, deploy, and prove live claims/alerts. |
 | MX-03 | Thanos Wallet | Repository work merged and deployed; acceptance open | EXTERNAL BLOCKER | Wallet team completes the published-version browser matrix, signed transaction, and approval record. |
-| MX-04 | DNNS | Merged and deployed; live-name acceptance open | EXTERNAL BLOCKER | Obtain two stable test names and DNNS interface/cache confirmation. |
+| MX-04 | DNNS | Live v0 verified; explorer safety hardening under review | IN PROGRESS | Merge/deploy the verified resolver behavior, then obtain interface, reverse-record, and cache-policy acceptance. |
 | MX-05 | Quantt | Adapter deployed but deliberately unconfigured | EXTERNAL BLOCKER | Obtain API contract/credential and repair or replace the development TLS endpoint. |
 | MX-01 | MultX / Lithoswap | Candidate source merged; Makalu swap disabled | IN PROGRESS | Resolve open DEX PRs, audit, deploy, seed approved liquidity, and run live acceptance. |
 | MX-07 | Developer toolchain | Expanded v0 local-only; no deployable compiler/release | IN PROGRESS, LOCAL ONLY | Review local tools, then implement compiler lowering/codegen and conformance. |
@@ -61,7 +61,7 @@ to the next executable stream without pretending the blocked stream is complete.
 1. [ ] **MX-06 Validator cleanup and safety** — waiting on responder/custodian governance and public backup recipient.
 2. [ ] **MX-02 LEP100 faucet assets** — safeguards and image publishing merged; key rotation, VPS wrapper activation, funding, live claims, and alerts remain.
 3. [ ] **MX-03 Thanos Wallet** — next after MX-02 repository work is verified.
-4. [ ] **MX-04 DNNS** — waiting on stable test records and team confirmation.
+4. [ ] **MX-04 DNNS** — active: verified forward records exist; repository hardening and deployment are next.
 5. [ ] **MX-05 Quantt** — waiting on API/TLS/product contract.
 6. [ ] **MX-01 MultX / Lithoswap** — security, deployment, liquidity, and acceptance remain.
 7. [ ] **MX-07 Developer toolchain** — separate major compiler/release program.
@@ -257,9 +257,13 @@ Evidence:
 
 **Owners:** Dev Infra + DNNS team
 
-**Current state:** Forward `.litho` search and reverse address display are merged and tested. Resolution reads the
-DNNS registry on Kamet (`900523`) through `https://rpc-3.litho.ai`. The integration still needs known-name live tests,
-an agreed cache policy, and DNNS-team acceptance.
+**Current state:** Forward `.litho` search and reverse address display are merged and deployed. Direct source and
+on-chain verification identified the supported deployed v0 as a Kamet-only (`900523`) registry at
+`0x316dc15bF377F7187e5BE38BA19e673Ca823d1ab` through `https://rpc-3.litho.ai`. All nine reserved names resolve to
+the deployment address. Repository hardening removes process-lifetime negative caching, separates an RPC failure
+from a missing record, enforces the deployed 2LD normalization rules, and forward-verifies reverse names before
+display. The public documentation describes a different Makalu-oriented reference architecture without deployed
+addresses, and the deployed v0 currently has no reverse record for the shared reserved-name address.
 
 Completed or evidenced:
 
@@ -267,16 +271,23 @@ Completed or evidenced:
 - [x] Explorer search navigates resolved names to address pages.
 - [x] Address pages can display reverse-resolved names.
 - [x] Five DNNS tests pass (2026-08-03).
+- [x] Deployment metadata and contract bytecode were independently verified against Kamet chain ID `900523`.
+- [x] All nine source-controlled reserved names resolve live to
+      `0xE9267bDf7084815B0754545049AE45FE744Aefa8` (2026-08-14).
+- [x] Deployed label rules were traced to the names portal and encoded in explorer normalization tests.
+- [x] Process-lifetime positive/negative caching was removed so new records can appear without a process restart.
+- [x] RPC failures are distinguished from unset records, and reverse results require forward verification.
 
 Remaining actions:
 
-- [ ] Obtain at least two stable registered test names and expected addresses from the DNNS team.
-- [ ] Confirm the registry/resolver addresses, Kamet RPC, TLD, normalization rules, and reverse-record rules as the
-      supported production interface.
-- [ ] Agree on positive and negative cache TTLs; replace process-lifetime negative caching if records must become
-      visible without a page/process restart.
-- [ ] Smoke-test forward and reverse resolution from the deployed explorer, including missing/malformed names and
-      RPC failure.
+- [ ] Review, merge, and deploy the resolver safety and normalization changes with their focused tests.
+- [ ] DNNS owner confirms the verified Kamet v0 deployment remains the supported explorer interface or provides a
+      reviewed replacement deployment and migration date.
+- [ ] DNNS owner updates public documentation with authoritative network IDs, contract addresses, normalization,
+      and reverse-record rules; current public reference material conflicts with deployed v0.
+- [ ] DNNS owner configures or nominates one stable reverse record and supplies its expected address/name pair.
+- [ ] Agree on the no-persistent-cache policy or provide bounded positive/negative TTL requirements.
+- [ ] Smoke-test forward, reverse, missing/malformed names, and RPC failure from the newly deployed explorer release.
 - [ ] Obtain DNNS-team acceptance.
 
 Acceptance criteria:
@@ -292,6 +303,8 @@ Evidence:
 - `Makalu/explorer/components/DnnsName.tsx`
 - `Makalu/explorer/components/SearchBar.tsx`
 - `Makalu/explorer/test/dnns.test.tsx`
+- `Makalu/explorer/test/dnns-resolver.test.ts`
+- `docs/dnns-acceptance.md`
 - Public DNNS documentation: `https://dnns.litho.ai/`
 
 ## MX-05 — Quantt integration
@@ -518,11 +531,27 @@ Evidence:
 | 2026-08-14 | Thanos deployment | ROLLED BACK | Run `31819790372` served the correct release SHA and passed core routes, but an incorrectly coupled faucet-schema condition failed; automatic rollback passed and restored the prior healthy release. |
 | 2026-08-14 | Thanos deployment retry | PASS | PR #84 merged as `4fdb3ca`; run `31822244365` attempt 2 passed the core public gate. Live version, `/signin`, `/nfts`, stats, and nonce probes passed; faucet container start time and image remained unchanged. |
 | 2026-08-14 | DNNS registry | PASS | Kamet chain ID 900523; configured registry address contains contract bytecode. |
+| 2026-08-14 | DNNS forward records | PASS | All nine deployment-reserved `.litho` names resolve to the expected checksum address through their registry-selected resolver. |
+| 2026-08-14 | DNNS reverse record | BLOCKED | The reverse node for the reserved-name address has no resolver; DNNS owner must configure or nominate a stable fixture. |
+| 2026-08-14 | DNNS repository verification | PASS | All 134 explorer tests passed. Next compilation/type validation and static generation passed; Windows standalone symlink creation was denied by local OS policy. |
 | 2026-08-14 | Quantt | BLOCKED | Live adapter reports `configured: false`; development hostname fails TLS validation. |
 | 2026-08-14 | Mainnet chain monitor | PASS | Three latest inspected protected runs passed. |
 | 2026-08-14 | Signing-state backup | BLOCKED | Scheduled workflow fails closed because `BACKUP_RECIPIENT` is empty. |
 
 ## Change log
+
+### 2026-08-14 — MX-04 deployed interface verified and explorer hardened
+
+- Traced the explorer configuration to the deployed Kamet v0 metadata instead of assuming the public reference
+  documentation represented a live migration.
+- Confirmed registry bytecode and all nine reserved forward records directly on chain. The deployed reverse node is
+  unset, so reverse acceptance remains an owner action rather than an explorer code task.
+- Removed process-lifetime record caching, enforced the deployed 2LD normalization rules, distinguished resolver
+  outages from missing records, and required forward verification before displaying a reverse name.
+- Added the evidence and owner sign-off fields in `docs/dnns-acceptance.md`.
+- All 134 explorer tests passed. Next compilation, type validation, and static generation passed; the final local
+  standalone-copy step remains blocked by Windows symlink policy and will be rechecked by Linux CI.
+- Updated by: `bachal-mb`.
 
 ### 2026-08-14 — MX-03 merged and deployed; wallet acceptance remains
 


### PR DESCRIPTION
## Outcome
- enforce the deployed Kamet v0 .litho normalization rules
- distinguish unavailable resolution from missing records and remove process-lifetime negative caching
- forward-verify reverse records before displaying them
- record the verified deployment, nine live forward fixtures, missing reverse fixture, and remaining DNNS-owner acceptance

## Verification
- 134 explorer tests passed
- Next.js compilation, type validation, and static generation passed
- final standalone copy is blocked locally by Windows symlink policy; Linux CI is authoritative
- git diff --check passed

## Safety
- read-only explorer change; no contract or DNS mutation
- faucet remains outside the core deployment workflow