### PR TITLE
fix(makalu): require explicit Quantt contract settings

### DIFF
--- a/Makalu/api/src/__tests__/quantt.test.ts
+++ b/Makalu/api/src/__tests__/quantt.test.ts
@@ -45,6 +45,32 @@ describe('Quantt integration', () => {
     expect(loadQuanttConfig({ QUANTT_API_BASE_URL: 'http://dev.quantt.at', QUANTT_API_KEY: 'key' })).toBeNull();
     expect(loadQuanttConfig({ QUANTT_API_BASE_URL: 'https://quantt.at.evil.example', QUANTT_API_KEY: 'key' })).toBeNull();
     expect(loadQuanttConfig({ QUANTT_API_BASE_URL: 'https://dev.quantt.at', QUANTT_API_KEY: 'key', QUANTT_INSIGHTS_PATH: '//evil.example' })).toBeNull();
+    expect(loadQuanttConfig({
+      QUANTT_API_BASE_URL: 'https://api.quantt.at?redirect=https://evil.example',
+      QUANTT_API_KEY: 'key',
+      QUANTT_API_AUTH_HEADER: 'authorization',
+      QUANTT_INSIGHTS_PATH: '/v1/insights',
+    })).toBeNull();
+  });
+
+  it('requires an explicit approved auth scheme and insights path', () => {
+    const base = {
+      QUANTT_API_BASE_URL: 'https://api.quantt.at',
+      QUANTT_API_KEY: 'server-secret',
+    };
+    expect(loadQuanttConfig(base)).toBeNull();
+    expect(loadQuanttConfig({ ...base, QUANTT_API_AUTH_HEADER: 'authorization' })).toBeNull();
+    expect(loadQuanttConfig({ ...base, QUANTT_INSIGHTS_PATH: '/v1/insights' })).toBeNull();
+    expect(loadQuanttConfig({
+      ...base,
+      QUANTT_API_AUTH_HEADER: 'cookie',
+      QUANTT_INSIGHTS_PATH: '/v1/insights',
+    })).toBeNull();
+    expect(loadQuanttConfig({
+      ...base,
+      QUANTT_API_AUTH_HEADER: 'authorization',
+      QUANTT_INSIGHTS_PATH: '/v1/insights',
+    })).toMatchObject({ authHeader: 'Authorization', insightsPath: '/v1/insights' });
   });
 
   it('proxies an insight without exposing credentials', async () => {

--- a/Makalu/api/src/quantt.ts
+++ b/Makalu/api/src/quantt.ts
@@ -28,13 +28,23 @@ export function loadQuanttConfig(env: NodeJS.ProcessEnv = process.env): QuanttCo
     return null;
   }
 
-  if (baseUrl.protocol !== 'https:' || !isQuanttHostname(baseUrl.hostname)) return null;
+  if (baseUrl.protocol !== 'https:'
+    || !isQuanttHostname(baseUrl.hostname)
+    || baseUrl.username
+    || baseUrl.password
+    || baseUrl.search
+    || baseUrl.hash) return null;
 
   const requestedHeader = env.QUANTT_API_AUTH_HEADER?.trim().toLowerCase();
-  const authHeader: QuanttAuthHeader = requestedHeader === 'x-api-key'
-    ? 'X-API-Key'
-    : 'Authorization';
-  const insightsPath = env.QUANTT_INSIGHTS_PATH?.trim() || '/api/v1/insights';
+  let authHeader: QuanttAuthHeader;
+  if (requestedHeader === 'x-api-key') authHeader = 'X-API-Key';
+  else if (requestedHeader === 'authorization') authHeader = 'Authorization';
+  else return null;
+
+  // The Quantt API contract has not been published. Require the owner-supplied
+  // path instead of activating against a guessed endpoint.
+  const insightsPath = env.QUANTT_INSIGHTS_PATH?.trim();
+  if (!insightsPath) return null;
   if (!insightsPath.startsWith('/') || insightsPath.startsWith('//')) return null;
 
   const requestedTimeout = Number(env.QUANTT_API_TIMEOUT_MS ?? 10_000);

--- a/docs/integrations/quantt.md
+++ b/docs/integrations/quantt.md
@@ -1,0 +1,88 @@
+# Quantt integration acceptance record
+
+- **Workstream:** MX-05
+- **Environment:** Makalu explorer and API
+- **Status:** Fail-closed; Quantt owner inputs and TLS repair required
+- **Last verified:** 2026-08-14
+
+This is the activation and acceptance record for the Quantt explorer integration. Similar-looking domains, guessed
+paths, inferred authentication, and inferred response fields are not acceptable evidence.
+
+## Verified public state
+
+| Surface | Result | Evidence |
+| --- | --- | --- |
+| Makalu status | PASS (disabled) | `https://makalu.litho.ai/api/quantt/status` returns HTTP 200 with `configured: false` and `apiOrigin: null`. |
+| Research portal | PASS | `https://research.quantt.at/` returns HTTP 200 with title `Quantt Agents Research`. |
+| Requested developer portal | FAIL | A standards-valid HTTPS request to `https://dev.quantt.at/` fails hostname verification. |
+| Developer DNS | OBSERVED | `dev.quantt.at` resolves to `91.236.195.168` at verification time. |
+| Presented certificate | WRONG HOST | Certificate subject is `CN=dev.quantts.ai`; SANs cover `api.quantts.ai`, `dev.quantts.ai`, `engine.quantts.ai`, and `enterprise.quantts.ai`, but not `dev.quantt.at`. |
+
+The similarly named `https://dev.quantts.ai/` currently returns HTTP 200 and `https://api.quantts.ai/` returns HTTP
+404 at its root. They are observations only. Neither domain is approved as the Lithosphere integration API, and the
+explorer must not switch to them without Quantt-owner confirmation.
+
+## Repository integration boundary
+
+The explorer contains a disabled research page and a server-only API proxy. Credentials are never sent to the
+browser. Activation requires all of these explicit server settings:
+
+| Setting | Required owner input |
+| --- | --- |
+| `QUANTT_API_BASE_URL` | Approved HTTPS API origin under the approved Quantt domain. |
+| `QUANTT_API_KEY` | Credential delivered through the deployment secret manager, never chat or source control. |
+| `QUANTT_API_AUTH_HEADER` | Exactly `authorization` or `x-api-key`, confirmed by Quantt. |
+| `QUANTT_INSIGHTS_PATH` | Exact approved path beginning with one `/`. |
+| `QUANTT_API_TIMEOUT_MS` | Optional; bounded by the adapter to 1–30 seconds. |
+
+The adapter does not default the auth scheme or insights path. It rejects HTTP, userinfo, query/hash-bearing base
+URLs, unrelated hostnames, protocol-relative paths, and malformed symbols. The upstream credential remains
+server-side and sanitized errors do not return it to clients.
+
+## Inputs still required from Quantt
+
+- [ ] Confirm the canonical production and development hostnames; explicitly state whether any `quantts.ai` host is
+      intended to replace the requested `quantt.at` host.
+- [ ] Repair the `dev.quantt.at` DNS/certificate binding or retire that URL in writing.
+- [ ] Provide the exact base URL, HTTP method, insights path, authentication scheme, and credential through the
+      approved secret manager.
+- [ ] Provide the versioned request/response schema, required headers, supported symbols, score units/range,
+      timestamp semantics, rate limits, timeout/retry guidance, and cache policy.
+- [ ] Provide non-secret success and error fixtures plus a test credential or sandbox access.
+- [ ] Name the Quantt technical approver and incident/contact channel.
+
+## Controlled activation sequence
+
+1. Review the owner-supplied API contract and replace the provisional response normalizer with the exact versioned
+   schema mapping and validation.
+2. Add contract fixtures for success, authentication failure, rate limiting, timeout, malformed JSON, oversized
+   response, and upstream 5xx behavior.
+3. Repair/validate the developer TLS endpoint and record certificate hostname/expiry evidence.
+4. Add the approved non-secret settings and secret-manager credential to the Makalu deployment environment.
+5. Deploy an immutable release through the protected core workflow; do not modify the faucet.
+6. Confirm `/api/quantt/status` reports configured without exposing the key, then run bounded live insight tests.
+7. Test the explorer's loading, empty, error, stale/cache, and successful result states.
+8. Record Quantt and Dev Infra acceptance below.
+
+## Acceptance criteria
+
+- [ ] Canonical hosts pass DNS, certificate-chain, hostname, and HTTPS checks.
+- [ ] The implemented request and response mapping matches a versioned owner-approved contract.
+- [ ] Credentials exist only in the secret manager/API process and are absent from responses, logs, and browser
+      assets.
+- [ ] Rate limits, timeouts, response-size bounds, retry behavior, caching, and error translation are tested.
+- [ ] A live LITHO request returns the expected mapped result through the Makalu explorer.
+- [ ] Disable/rollback behavior is tested and documented.
+- [ ] Quantt and Dev Infra approvers, date, release, and evidence are recorded.
+
+## Evidence and approval
+
+| Field | Value |
+| --- | --- |
+| Repository PR | Pending |
+| Merge commit | Pending |
+| Deployment run/release | Pending |
+| Quantt contract/version | Pending |
+| Live test artifact | Pending |
+| Quantt approver/date | Pending |
+| Dev Infra approver/date | Pending |

--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -1,10 +1,10 @@
 # Makalu extra works — living handoff
 
 - **Status:** Active — closing one stream at a time
-- **Last verified:** 2026-08-14 23:10 PKT (UTC+05:00)
+- **Last verified:** 2026-08-14 23:26 PKT (UTC+05:00)
 - **Repository:** `KaJLabs/Lithosphere`
-- **Default branch inspected:** `origin/main` at `c5448da8c617cf06083f9c08be7e08bd1b5cb6b2`
-- **Latest merged closure:** PR #86 at `c5448da8c617cf06083f9c08be7e08bd1b5cb6b2`
+- **Default branch inspected:** `origin/main` at `112359eb34c7a4a61bba35493e8b87524d18d49d`
+- **Latest merged closure:** PR #87 at `112359eb34c7a4a61bba35493e8b87524d18d49d`
 - **Network in scope:** Makalu testnet, EVM chain ID `700777`, Cosmos chain ID `lithosphere_700777-2`
 
 This is the source of truth for the seven Makalu extra-work streams. Update it whenever code is merged, a release is
@@ -49,7 +49,7 @@ into a reviewable change, and never bulk-commit the dirty worktree.
 | MX-02 | LEP100 faucet assets | Safeguards and secured image pipeline merged; production release remains manual | EXTERNAL BLOCKER | Rotate the exposed faucet key, install the protected wrapper, fund assets, deploy, and prove live claims/alerts. |
 | MX-03 | Thanos Wallet | Repository work merged and deployed; acceptance open | EXTERNAL BLOCKER | Wallet team completes the published-version browser matrix, signed transaction, and approval record. |
 | MX-04 | DNNS | Verified explorer hardening merged and deployed; owner acceptance open | EXTERNAL BLOCKER | DNNS owner confirms the supported interface, fixes public docs, nominates a reverse record, and accepts cache policy. |
-| MX-05 | Quantt | Adapter deployed but deliberately unconfigured | EXTERNAL BLOCKER | Obtain API contract/credential and repair or replace the development TLS endpoint. |
+| MX-05 | Quantt | Adapter disabled; assumption-free activation gates under review | IN PROGRESS | Merge/deploy explicit auth/path requirements, then obtain API contract/credential and repair the development TLS endpoint. |
 | MX-01 | MultX / Lithoswap | Candidate source merged; Makalu swap disabled | IN PROGRESS | Resolve open DEX PRs, audit, deploy, seed approved liquidity, and run live acceptance. |
 | MX-07 | Developer toolchain | Expanded v0 local-only; no deployable compiler/release | IN PROGRESS, LOCAL ONLY | Review local tools, then implement compiler lowering/codegen and conformance. |
 
@@ -62,7 +62,7 @@ to the next executable stream without pretending the blocked stream is complete.
 2. [ ] **MX-02 LEP100 faucet assets** — safeguards and image publishing merged; key rotation, VPS wrapper activation, funding, live claims, and alerts remain.
 3. [ ] **MX-03 Thanos Wallet** — next after MX-02 repository work is verified.
 4. [ ] **MX-04 DNNS** — deployed; waiting on DNNS-owner interface, documentation, reverse-record, and cache-policy acceptance.
-5. [ ] **MX-05 Quantt** — waiting on API/TLS/product contract.
+5. [ ] **MX-05 Quantt** — active: remove guessed activation defaults and publish the verified owner handoff.
 6. [ ] **MX-01 MultX / Lithoswap** — security, deployment, liquidity, and acceptance remain.
 7. [ ] **MX-07 Developer toolchain** — separate major compiler/release program.
 
@@ -319,10 +319,12 @@ Evidence:
 
 **Owners:** Dev Infra + Quantt team + product owner
 
-**Current state:** The credentials-safe server proxy, explorer page, normalizer, tests, OpenAPI paths, configuration,
-and runbook are implemented. The live status endpoint now exists but reports `configured: false`. The public research
-site responds, while `dev.quantt.at` fails hostname verification. The adapter intentionally fails closed without an
-approved API contract and key.
+**Current state:** The credentials-safe server proxy, explorer page, provisional normalizer, tests, and OpenAPI paths
+are deployed. The live status endpoint reports `configured: false`. The research site returns HTTP 200.
+`dev.quantt.at` resolves to `91.236.195.168`, but presents a certificate for `quantts.ai` names and fails hostname
+verification. The similarly named `dev.quantts.ai` is reachable, but is not an approved substitute. Repository
+hardening is removing guessed auth/path defaults and adding the previously missing acceptance runbook. The adapter
+must remain fail-closed until the exact owner-approved contract and secret-manager credential are available.
 
 Completed or evidenced:
 
@@ -330,6 +332,11 @@ Completed or evidenced:
 - [x] Server-only authentication, symbol validation, bounded timeouts, and sanitized upstream errors exist.
 - [x] `/api/quantt/status`, `/api/quantt/insights`, `/quantt`, tests, and OpenAPI documentation exist.
 - [x] Live `/api/quantt/status` returns HTTP 200 and safely reports unconfigured (2026-08-03).
+- [x] Live status, research portal, developer DNS, and the mismatched certificate subject/SANs were reverified on
+      2026-08-14 without bypassing TLS for acceptance.
+- [x] The unapproved `quantts.ai` lookalike was recorded but not substituted for the requested domain.
+- [x] Activation now requires an explicit auth scheme and insights path instead of guessed defaults locally.
+- [x] Five focused Quantt tests, all 164 API tests, and the strict TypeScript build pass locally (2026-08-14).
 
 External inputs required:
 
@@ -342,6 +349,7 @@ External inputs required:
 
 Remaining actions after inputs arrive:
 
+- [ ] Review, merge, and deploy the explicit activation gates and `docs/integrations/quantt.md`.
 - [ ] Add schema validation and contract fixtures for approved responses.
 - [ ] Configure secrets in staging without placing keys in client bundles, files, or logs.
 - [ ] Validate reference symbols, empty results, rate limits, timeouts, and upstream failures.
@@ -545,10 +553,26 @@ Evidence:
 | 2026-08-14 | DNNS merge and deployment | PASS | PR #86 passed all checks and merged as `c5448da`; protected run `31826844798` deployed that exact release and passed the public health gate. |
 | 2026-08-14 | DNNS post-deployment smoke | PASS | Public version reports `c5448da`; home/blocks return 200, shipped validation text is present, and `makalu.litho`/`faucet.litho` resolve to the expected address. |
 | 2026-08-14 | Quantt | BLOCKED | Live adapter reports `configured: false`; development hostname fails TLS validation. |
+| 2026-08-14 | Quantt public surfaces | PARTIAL | Research portal HTTP 200. `dev.quantt.at` resolves, but its certificate covers only `quantts.ai` names; the similar domain is not approved as a replacement. |
+| 2026-08-14 | Quantt activation audit | IN PROGRESS | Base URL/key gate exists, but auth and path defaults were guessed. Local hardening requires both explicitly and adds the missing acceptance record. |
+| 2026-08-14 | Quantt repository verification | PASS | Five focused tests and all 164 API tests passed; nine live-integration tests remained intentionally skipped; strict TypeScript build passed. |
 | 2026-08-14 | Mainnet chain monitor | PASS | Three latest inspected protected runs passed. |
 | 2026-08-14 | Signing-state backup | BLOCKED | Scheduled workflow fails closed because `BACKUP_RECIPIENT` is empty. |
 
 ## Change log
+
+### 2026-08-14 — MX-05 verified and assumption-based activation removed locally
+
+- Reverified the deployed adapter is disabled, the research portal is healthy, and standards-valid access to
+  `dev.quantt.at` fails hostname verification.
+- Inspected the presented certificate: it covers `quantts.ai` hosts, not the requested `dev.quantt.at`. The similar
+  domain was observed but deliberately not substituted without Quantt-owner approval.
+- Changed local configuration loading to require an explicit approved auth header and insights path rather than
+  defaulting to an assumed Bearer scheme and `/api/v1/insights`.
+- Added `docs/integrations/quantt.md` with verified evidence, exact owner inputs, activation sequence, acceptance
+  criteria, and approval fields.
+- Five focused Quantt tests, all 164 API tests, and the strict TypeScript build passed.
+- Updated by: `bachal-mb`.
 
 ### 2026-08-14 — MX-04 merged and deployed; owner acceptance remains
 


### PR DESCRIPTION
## Outcome
- keep Quantt fail-closed unless auth scheme and insights path are explicitly approved
- reject credential-bearing or query/hash-bearing base URLs
- record live status, healthy research portal, the exact dev.quantt.at certificate mismatch, and owner inputs
- do not substitute the unapproved quantts.ai lookalike

## Verification
- 5 focused Quantt tests passed
- all 164 API tests passed; 9 live-integration tests intentionally skipped
- strict TypeScript build passed
- git diff --check passed

## Deployment behavior
The production Quantt configuration is currently absent, so this release remains configured:false. No credential, API-domain substitution, faucet change, or external mutation is included.