### PR TITLE
fix(multx): harden provider-neutral signer quorum

### DIFF
--- a/MultX/api/src/routes/bridge.js
+++ b/MultX/api/src/routes/bridge.js
@@ -1,5 +1,10 @@
 import express from 'express';
+import { config } from '../config.js';
 import { pool } from '../db/pool.js';
+import {
+  getAllowedSignerAddresses,
+  getSignaturesRequired,
+} from '../services/validatorService.js';
 
 const router = express.Router();
 
@@ -16,14 +21,16 @@ const statusMapping = {
 router.get('/status/:txHash', async (req, res, next) => {
   try {
     const { txHash } = req.params;
+    const allowedSigners = config.useMockValidator ? null : getAllowedSignerAddresses();
 
     const result = await pool.query(
-      `SELECT bt.*, COUNT(bs.id)::int AS signatures_collected
+      `SELECT bt.*, COUNT(DISTINCT LOWER(bs.validator_address))::int AS signatures_collected
        FROM bridge_transactions bt
        LEFT JOIN bridge_signatures bs ON bs.tx_hash = bt.tx_hash
+        AND ($2::text[] IS NULL OR LOWER(bs.validator_address) = ANY($2::text[]))
        WHERE bt.tx_hash = $1
        GROUP BY bt.tx_hash`,
-      [txHash]
+      [txHash, allowedSigners]
     );
 
     if (result.rows.length === 0) {
@@ -37,13 +44,15 @@ router.get('/status/:txHash', async (req, res, next) => {
       tokenAddress: tx.token_address,
       releaseToken: tx.release_token,
       amount: tx.amount,
-      sourceChain: tx.source_chain ? Number(tx.source_chain) : 900523,
+      sourceChain: tx.source_chain ? Number(tx.source_chain) : null,
       targetChain: tx.target_chain ? Number(tx.target_chain) : null,
       sourceNonce: tx.source_nonce,
       status: statusMapping[tx.status] || tx.status,
       dbStatus: tx.status,
       signaturesCollected: tx.signatures_collected,
-      signaturesRequired: 2,
+      signaturesRequired: config.useMockValidator
+        ? config.mockSignaturesRequired
+        : getSignaturesRequired(),
       blockNumber: tx.block_number,
       timestamp: tx.timestamp,
       releaseTxHash: tx.release_tx_hash
@@ -57,10 +66,14 @@ router.get('/status/:txHash', async (req, res, next) => {
 router.get('/signatures/:txHash', async (req, res, next) => {
   try {
     const { txHash } = req.params;
+    const allowedSigners = config.useMockValidator ? null : getAllowedSignerAddresses();
 
     const result = await pool.query(
-      `SELECT signature FROM bridge_signatures WHERE tx_hash = $1 ORDER BY validator_address ASC`,
-      [txHash]
+      `SELECT DISTINCT ON (LOWER(validator_address)) signature FROM bridge_signatures
+       WHERE tx_hash = $1
+         AND ($2::text[] IS NULL OR LOWER(validator_address) = ANY($2::text[]))
+       ORDER BY LOWER(validator_address) ASC, id ASC`,
+      [txHash, allowedSigners]
     );
 
     res.json({

--- a/MultX/api/src/services/releaseService.js
+++ b/MultX/api/src/services/releaseService.js
@@ -99,12 +99,16 @@ async function markCompleted(txHash, releaseTxHash) {
 }
 
 async function releaseOne(tx) {
+  if (!tx.release_token || !tx.source_chain || !tx.source_nonce) {
+    console.warn(`[ReleaseService] incomplete release evidence — skipping ${short(tx.tx_hash)}`);
+    return;
+  }
   const ctx = await getChainCtx(tx.target_chain);
   if (!ctx) {
     console.warn(`[ReleaseService] no dest bridge for chain ${tx.target_chain} — skipping ${short(tx.tx_hash)}`);
     return;
   }
-  const token = tx.release_token || tx.token_address;
+  const token = tx.release_token;
   const amount = BigInt(tx.amount);
 
   // Idempotency: already released on-chain (e.g. the user claimed via the

--- a/MultX/api/src/services/remoteSigner.js
+++ b/MultX/api/src/services/remoteSigner.js
@@ -11,6 +11,19 @@ const requiredFile = (path, label) => {
   return value;
 };
 
+export const validateSignerUrl = (value) => {
+  let url;
+  try { url = new URL(value); } catch { throw new Error('remote signer URL must be valid'); }
+  if (url.protocol !== 'https:') throw new Error('remote signer URL must use https');
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('remote signer URL must not contain credentials, query parameters, or a fragment');
+  }
+  if (url.pathname !== '/' && url.pathname !== '') {
+    throw new Error('remote signer URL must be an origin without a path');
+  }
+  return url.origin;
+};
+
 const requestJson = ({ baseUrl, path, method, body, tls, timeoutMs }) => new Promise((resolve, reject) => {
   const url = new URL(path, baseUrl);
   if (url.protocol !== 'https:') {
@@ -102,6 +115,7 @@ export const createRemoteSigner = async ({
   timeoutMs = 8_000,
 }) => {
   const address = ethers.getAddress(expectedAddress);
+  const baseUrl = validateSignerUrl(url);
   const tls = {
     ca: requiredFile(caFile, `VALIDATOR_SIGNER_CA_FILE_${index}`),
     cert: requiredFile(certFile, `VALIDATOR_SIGNER_CERT_FILE_${index}`),
@@ -109,7 +123,7 @@ export const createRemoteSigner = async ({
   };
 
   const identity = await requestJson({
-    baseUrl: url,
+    baseUrl,
     path: '/v1/identity',
     method: 'GET',
     tls,
@@ -126,7 +140,7 @@ export const createRemoteSigner = async ({
     address,
     async signRelease(attestation) {
       const response = await requestJson({
-        baseUrl: url,
+        baseUrl,
         path: '/v1/sign-release',
         method: 'POST',
         body: { version: 1, ...attestation },

--- a/MultX/api/src/services/validatorPolicy.js
+++ b/MultX/api/src/services/validatorPolicy.js
@@ -1,0 +1,31 @@
+import { ethers } from 'ethers';
+
+export function positiveSafeInteger(value, label) {
+  const text = String(value ?? '');
+  if (!/^[1-9][0-9]*$/.test(text)) throw new Error(`${label} must be a positive integer`);
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${label} exceeds JavaScript's safe integer range`);
+  return parsed;
+}
+
+export function validateValidatorSet(validators, signaturesRequired) {
+  const required = positiveSafeInteger(signaturesRequired, 'SIGNATURES_REQUIRED');
+  if (!Array.isArray(validators) || validators.length === 0) {
+    throw new Error('No validator signers are configured');
+  }
+  const addresses = validators.map((validator, index) => {
+    try {
+      const address = ethers.getAddress(validator.address);
+      if (address === ethers.ZeroAddress) throw new Error('zero address');
+      return address.toLowerCase();
+    }
+    catch { throw new Error(`validator ${index} has an invalid address`); }
+  });
+  if (new Set(addresses).size !== addresses.length) {
+    throw new Error('validator signer addresses must be unique');
+  }
+  if (addresses.length < required) {
+    throw new Error(`Loaded ${addresses.length} signer(s), below configured threshold ${required}`);
+  }
+  return { required, addresses };
+}

--- a/MultX/api/src/services/validatorService.js
+++ b/MultX/api/src/services/validatorService.js
@@ -3,9 +3,13 @@ import { ethers } from 'ethers';
 import { config } from '../config.js';
 import { pool } from '../db/pool.js';
 import { createRemoteSigner } from './remoteSigner.js';
+import { positiveSafeInteger, validateValidatorSet } from './validatorPolicy.js';
 
 let validators = [];
+let allowedSignerAddresses = [];
+let signaturesRequired = null;
 let signingIntervalId = null;
+let signingRunning = false;
 
 /**
  * Production uses one independently operated HTTPS signer per validator,
@@ -15,7 +19,7 @@ let signingIntervalId = null;
  * File-backed keys exist only for local development and tests. Production
  * rejects them so a single API VPS cannot silently hold the whole quorum.
  */
-async function loadValidators() {
+async function loadValidators(timeoutMs) {
   const loaded = [];
 
   for (let i = 0; i < 10; i++) {
@@ -29,7 +33,7 @@ async function loadValidators() {
         caFile: process.env[`VALIDATOR_SIGNER_CA_FILE_${i}`],
         certFile: process.env[`VALIDATOR_SIGNER_CERT_FILE_${i}`],
         keyFile: process.env[`VALIDATOR_SIGNER_KEY_FILE_${i}`],
-        timeoutMs: parseInt(process.env.VALIDATOR_SIGNER_TIMEOUT_MS || '8000', 10),
+        timeoutMs,
       }));
     } catch (err) {
       throw new Error(`[ValidatorService] remote signer ${i} initialization failed: ${err.message}`);
@@ -56,10 +60,11 @@ export async function startValidatorService() {
   if (process.env.NODE_ENV === 'production' && !process.env.SIGNATURES_REQUIRED) {
     throw new Error('[ValidatorService] SIGNATURES_REQUIRED must be explicit in production');
   }
-  if (!Number.isSafeInteger(config.signaturesRequired) || config.signaturesRequired < 1) {
-    throw new Error('[ValidatorService] SIGNATURES_REQUIRED must be a positive safe integer');
-  }
-  validators = await loadValidators();
+  const timeoutMs = positiveSafeInteger(
+    process.env.VALIDATOR_SIGNER_TIMEOUT_MS || '8000',
+    'VALIDATOR_SIGNER_TIMEOUT_MS',
+  );
+  validators = await loadValidators(timeoutMs);
 
   if (validators.length === 0) {
     throw new Error(
@@ -68,12 +73,12 @@ export async function startValidatorService() {
       'Local development may use VALIDATOR_PRIVATE_KEY_FILE_0..N or MOCK_VALIDATOR=true.'
     );
   }
-  if (validators.length < config.signaturesRequired) {
-    throw new Error(
-      `[ValidatorService] Loaded ${validators.length} signer(s), below configured threshold ` +
-      `${config.signaturesRequired}. Refusing to start.`
-    );
-  }
+  const validated = validateValidatorSet(
+    validators,
+    process.env.SIGNATURES_REQUIRED || String(config.signaturesRequired),
+  );
+  allowedSignerAddresses = validated.addresses;
+  signaturesRequired = validated.required;
 
   const remoteCount = validators.filter((v) => v.kind === 'remote').length;
   const fileCount = validators.filter((v) => v.kind === 'filekey').length;
@@ -108,6 +113,8 @@ async function signWith(validator, attestation) {
 }
 
 async function processSignings() {
+  if (signingRunning) return;
+  signingRunning = true;
   try {
     const result = await pool.query(
       `SELECT tx_hash, from_address, token_address, release_token, amount,
@@ -118,11 +125,15 @@ async function processSignings() {
     if (result.rows.length === 0) return;
 
     for (const tx of result.rows) {
-      const releaseToken = tx.release_token || tx.token_address;
-      const sourceChain = tx.source_chain || 900523;
+      if (!tx.release_token || !tx.source_chain || !tx.source_nonce || !tx.block_number) {
+        console.error(`[ValidatorService] Refusing ${tx.tx_hash}: incomplete multichain lock evidence`);
+        continue;
+      }
+      const releaseToken = tx.release_token;
+      const sourceChain = tx.source_chain;
       const sourceSpec = config.chainsToWatch.find((c) => Number(c.chainId) === Number(sourceChain));
       const targetSpec = config.chainsToWatch.find((c) => Number(c.chainId) === Number(tx.target_chain));
-      if (!sourceSpec?.bridge || !targetSpec?.bridge || !tx.block_number) {
+      if (!sourceSpec?.bridge || !targetSpec?.bridge) {
         console.error(`[ValidatorService] Refusing ${tx.tx_hash}: missing source/target bridge or block evidence`);
         continue;
       }
@@ -163,11 +174,13 @@ async function processSignings() {
           );
 
           const sigResult = await pool.query(
-            `SELECT COUNT(*)::int AS sig_count FROM bridge_signatures WHERE tx_hash = $1`,
-            [tx.tx_hash]
+            `SELECT COUNT(DISTINCT LOWER(validator_address))::int AS sig_count
+             FROM bridge_signatures
+             WHERE tx_hash = $1 AND LOWER(validator_address) = ANY($2::text[])`,
+            [tx.tx_hash, allowedSignerAddresses]
           );
 
-          if (sigResult.rows[0].sig_count >= config.signaturesRequired) {
+          if (sigResult.rows[0].sig_count >= signaturesRequired) {
             await pool.query(
               `UPDATE bridge_transactions SET status = 'signed' WHERE tx_hash = $1`,
               [tx.tx_hash]
@@ -181,6 +194,8 @@ async function processSignings() {
     }
   } catch (err) {
     console.error('[ValidatorService] processSignings error:', err.message);
+  } finally {
+    signingRunning = false;
   }
 }
 
@@ -189,4 +204,12 @@ export function stopValidatorService() {
     clearInterval(signingIntervalId);
     console.log('[ValidatorService] Signing loop stopped');
   }
+}
+
+export function getSignaturesRequired() {
+  return signaturesRequired ?? config.signaturesRequired;
+}
+
+export function getAllowedSignerAddresses() {
+  return [...allowedSignerAddresses];
 }

--- a/MultX/api/test/remoteSigner.test.js
+++ b/MultX/api/test/remoteSigner.test.js
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ethers } from 'ethers';
-import { releaseMessageHash, verifyReleaseSignature } from '../src/services/remoteSigner.js';
+import {
+  releaseMessageHash,
+  validateSignerUrl,
+  verifyReleaseSignature,
+} from '../src/services/remoteSigner.js';
 
 const attestation = {
   sourceTxHash: `0x${'11'.repeat(32)}`,
@@ -26,6 +30,18 @@ test('accepts a signature from the configured validator', async () => {
     verifyReleaseSignature({ attestation, signature, expectedAddress: wallet.address }),
     signature,
   );
+});
+
+test('accepts only credential-free HTTPS signer origins', () => {
+  assert.equal(validateSignerUrl('https://signer-0.internal:9443'), 'https://signer-0.internal:9443');
+  for (const url of [
+    'http://signer-0.internal:9443',
+    'https://user:pass@signer-0.internal:9443',
+    'https://signer-0.internal:9443/path',
+    'https://signer-0.internal:9443?token=secret',
+  ]) {
+    assert.throws(() => validateSignerUrl(url));
+  }
 });
 
 test('rejects a signature if any signed release field changes', async () => {

--- a/MultX/api/test/validatorPolicy.test.js
+++ b/MultX/api/test/validatorPolicy.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { positiveSafeInteger, validateValidatorSet } from '../src/services/validatorPolicy.js';
+
+const A = '0x1111111111111111111111111111111111111111';
+const B = '0x2222222222222222222222222222222222222222';
+
+test('accepts a unique signer set at or above threshold', () => {
+  const result = validateValidatorSet([{ address: A }, { address: B }], 2);
+  assert.equal(result.required, 2);
+  assert.deepEqual(result.addresses, [A, B]);
+});
+
+test('rejects duplicate signer identities and a threshold above the unique set', () => {
+  assert.throws(
+    () => validateValidatorSet([{ address: A }, { address: A }], 2),
+    /must be unique/,
+  );
+  assert.throws(
+    () => validateValidatorSet([{ address: A }], 2),
+    /below configured threshold/,
+  );
+  assert.throws(
+    () => validateValidatorSet([{ address: '0x0000000000000000000000000000000000000000' }], 1),
+    /invalid address/,
+  );
+});
+
+test('rejects malformed, zero, negative, and unsafe operational integers', () => {
+  for (const value of ['', '0', '-1', '1.5', 'abc', '9007199254740992']) {
+    assert.throws(() => positiveSafeInteger(value, 'value'));
+  }
+  assert.equal(positiveSafeInteger('8000', 'value'), 8000);
+});

--- a/MultX/contracts/contracts/MultXBridge.sol
+++ b/MultX/contracts/contracts/MultXBridge.sol
@@ -78,7 +78,7 @@ contract MultXBridge is Ownable, ReentrancyGuard, Pausable {
     event PauseGuardianUpdated(address indexed previousGuardian, address indexed newGuardian);
 
     /// @notice Deploy the bridge with an initial validator set and quorum threshold.
-    /// @param _validators Initial validator addresses (must be non-empty, no zero address).
+    /// @param _validators Initial validator addresses (must be non-empty, unique, and non-zero).
     /// @param _signaturesRequired Quorum size; must be in [1, _validators.length].
     constructor(address[] memory _validators, uint256 _signaturesRequired) Ownable(msg.sender) {
         require(_validators.length > 0, "At least one validator required");
@@ -86,6 +86,7 @@ contract MultXBridge is Ownable, ReentrancyGuard, Pausable {
 
         for (uint256 i = 0; i < _validators.length; i++) {
             require(_validators[i] != address(0), "Invalid validator address");
+            require(!isValidator[_validators[i]], "Duplicate validator address");
             isValidator[_validators[i]] = true;
             validators.push(_validators[i]);
         }
@@ -132,7 +133,7 @@ contract MultXBridge is Ownable, ReentrancyGuard, Pausable {
     // ── Admin: validator set rotation ───────────────────────────────────────────
 
     /// @notice Replace the entire validator set and quorum threshold atomically. Owner-only.
-    /// @param _validators New validator addresses (non-empty, no zero address).
+    /// @param _validators New validator addresses (non-empty, unique, and non-zero).
     /// @param _signaturesRequired New quorum size; must be in [1, _validators.length].
     function setValidatorSet(address[] calldata _validators, uint256 _signaturesRequired) external onlyOwner {
         require(_validators.length > 0, "At least one validator required");
@@ -149,6 +150,7 @@ contract MultXBridge is Ownable, ReentrancyGuard, Pausable {
         uint256 newLen = _validators.length;
         for (uint256 i = 0; i < newLen; i++) {
             require(_validators[i] != address(0), "Invalid validator address");
+            require(!isValidator[_validators[i]], "Duplicate validator address");
             isValidator[_validators[i]] = true;
             validators.push(_validators[i]);
         }

--- a/MultX/contracts/contracts/MultXBridgeDest.sol
+++ b/MultX/contracts/contracts/MultXBridgeDest.sol
@@ -91,7 +91,7 @@ contract MultXBridgeDest is Ownable, ReentrancyGuard, Pausable {
     event PauseGuardianUpdated(address indexed previousGuardian, address indexed newGuardian);
 
     /// @notice Deploy the destination bridge with an initial validator set and quorum.
-    /// @param _validators Initial validator addresses (non-empty, no zero address).
+    /// @param _validators Initial validator addresses (must be non-empty, unique, and non-zero).
     /// @param _signaturesRequired Quorum size; must be in [1, _validators.length].
     constructor(address[] memory _validators, uint256 _signaturesRequired) Ownable(msg.sender) {
         require(_validators.length > 0, "At least one validator required");
@@ -100,6 +100,7 @@ contract MultXBridgeDest is Ownable, ReentrancyGuard, Pausable {
         uint256 vlen = _validators.length;
         for (uint256 i = 0; i < vlen; i++) {
             require(_validators[i] != address(0), "Invalid validator address");
+            require(!isValidator[_validators[i]], "Duplicate validator address");
             isValidator[_validators[i]] = true;
             validators.push(_validators[i]);
         }
@@ -143,7 +144,7 @@ contract MultXBridgeDest is Ownable, ReentrancyGuard, Pausable {
     // ── Admin: validator set rotation ───────────────────────────────────────────
 
     /// @notice Replace the entire validator set and quorum threshold atomically. Owner-only.
-    /// @param _validators New validator addresses (non-empty, no zero address).
+    /// @param _validators New validator addresses (non-empty, unique, and non-zero).
     /// @param _signaturesRequired New quorum size; must be in [1, _validators.length].
     function setValidatorSet(address[] calldata _validators, uint256 _signaturesRequired) external onlyOwner {
         require(_validators.length > 0, "At least one validator required");
@@ -158,6 +159,7 @@ contract MultXBridgeDest is Ownable, ReentrancyGuard, Pausable {
         uint256 newLen = _validators.length;
         for (uint256 i = 0; i < newLen; i++) {
             require(_validators[i] != address(0), "Invalid validator address");
+            require(!isValidator[_validators[i]], "Duplicate validator address");
             isValidator[_validators[i]] = true;
             validators.push(_validators[i]);
         }

--- a/MultX/contracts/test/MultXBridge.test.js
+++ b/MultX/contracts/test/MultXBridge.test.js
@@ -58,6 +58,19 @@ describe("MultXBridge", function () {
     await token.mint(user.address, ethers.utils.parseEther("1000"));
   });
 
+  it("Rejects duplicate validators at deployment", async function () {
+    const MultXBridge = await ethers.getContractFactory("MultXBridge");
+    await expect(
+      MultXBridge.deploy([validator1.address, validator1.address], 2)
+    ).to.be.revertedWith("Duplicate validator address");
+  });
+
+  it("Rejects duplicate validators during rotation", async function () {
+    await expect(
+      bridge.setValidatorSet([validator1.address, validator1.address], 2)
+    ).to.be.revertedWith("Duplicate validator address");
+  });
+
   it("Should lock tokens", async function () {
     const amount = ethers.utils.parseEther("100");
     const targetChain = 1;

--- a/MultX/contracts/test/MultXBridgeDest.test.js
+++ b/MultX/contracts/test/MultXBridgeDest.test.js
@@ -92,6 +92,13 @@ describe("MultXBridgeDest", function () {
         Bridge.deploy([v1.address, ethers.constants.AddressZero], 1)
       ).to.be.revertedWith("Invalid validator address");
     });
+
+    it("Reverts on duplicate validator addresses", async function () {
+      const Bridge = await ethers.getContractFactory("MultXBridgeDest");
+      await expect(
+        Bridge.deploy([v1.address, v1.address], 2)
+      ).to.be.revertedWith("Duplicate validator address");
+    });
   });
 
   describe("lockTokens (reverse direction — burn wrapped, target LITHO)", function () {
@@ -339,6 +346,12 @@ describe("MultXBridgeDest", function () {
 
     it("Rejects threshold > validator count", async function () {
       await expect(bridge.setValidatorSet([v1.address], 2)).to.be.revertedWith("Invalid signatures required");
+    });
+
+    it("Rejects duplicate validator addresses", async function () {
+      await expect(
+        bridge.setValidatorSet([v1.address, v1.address], 2)
+      ).to.be.revertedWith("Duplicate validator address");
     });
 
     it("Non-owner cannot call", async function () {

--- a/MultX/docs/VPS_SIGNER_ARCHITECTURE.md
+++ b/MultX/docs/VPS_SIGNER_ARCHITECTURE.md
@@ -24,6 +24,16 @@ policy, then recomputes the same EIP-191 release hash enforced by
 `MultXBridge.releaseTokens`. The API independently recovers the returned
 signature and rejects any address other than the configured validator.
 
+Startup rejects duplicate signer identities, thresholds above the unique
+configured set, malformed timeouts, and non-origin signer URLs. Signing polls
+are serialized. Only distinct signatures from the current configured signer set
+advance the database threshold, and rows missing explicit source-chain,
+source-nonce, block, or release-token evidence fail closed.
+
+Each signer queries the actual source RPC chain ID rather than trusting a static
+provider hint. Both bridge contracts also reject duplicate validator identities
+at deployment and during validator-set rotation.
+
 The audit candidate binds every signature to the destination chain ID and
 destination bridge address in addition to the source event and release fields.
 Both bridge implementations, the API, independent signer and relayer recompute

--- a/MultX/signer/OPERATOR_RUNBOOK.md
+++ b/MultX/signer/OPERATOR_RUNBOOK.md
@@ -44,10 +44,19 @@ chat, email, source control or CI variables.
 - An unauthenticated TLS client is rejected.
 - A wrong source chain, bridge, token route, event, or insufficient-confirmation
   request is rejected without writing a signing decision.
+- A policy RPC pointed at the wrong chain ID is rejected.
+- Missing/malformed confirmation depth, an insecure remote RPC, duplicate
+  source/route, zero critical address, or corrupt journal prevents startup.
 - Repeating the same approved request returns the same signer identity and a
   valid signature; attempting equivocation for a signed source nonce is rejected.
 - Restarting the container preserves the journal and the equivocation decision.
 - Restore the encrypted backup onto a clean VPS and repeat the checks.
+- Configure duplicate signer identities and verify the coordinator refuses to
+  start; stale/unconfigured database signatures must not satisfy quorum.
+- Verify both bridge implementations reject duplicate validator identities at
+  deployment and during rotation.
+- Confirm a slow signing cycle cannot overlap the next coordinator poll and
+  incomplete multichain evidence is rejected rather than defaulted.
 
 ## Incident response
 

--- a/MultX/signer/README.md
+++ b/MultX/signer/README.md
@@ -12,12 +12,14 @@ Deployment templates and operator acceptance steps are in
 The signer does not blindly sign an API-provided digest. For every request it:
 
 1. validates the configured source chain, bridge, token route and destination;
-2. queries its own source-chain RPC;
-3. requires the configured confirmation depth;
+2. rejects duplicate routes, zero addresses, missing confirmation depth, and
+   non-HTTPS source RPCs (except loopback rehearsal);
+3. queries its own source-chain RPC, verifies its reported chain ID, and requires
+   the explicit confirmation depth;
 4. verifies the exact `TokensLocked` event at the supplied block;
 5. recomputes the release hash locally;
-6. records an fsync-backed `(sourceChain, sourceNonce) -> hash` decision and
-   rejects equivocation; and
+6. records an fsync-backed `(sourceChain, sourceNonce) -> hash` decision before
+   signing and rejects equivocation, including after restart; and
 7. returns an EIP-191 signature only after those checks pass.
 
 ## Required mounted files
@@ -34,6 +36,10 @@ The host should use full-disk encryption, SSH-key-only administration, a
 default-deny firewall allowing port 9443 only from the MultX API VPS, offline
 encrypted key backup, log shipping and uptime alerts. Validator operators must
 not share VPS accounts, private keys or TLS server keys.
+
+Each policy source must set an explicit positive `confirmations` value and a
+credential-free HTTPS `rpcUrl`. Every source chain and route must be unique.
+The signer fails startup on malformed policy or journal data.
 
 No production policy or key material is included. Bridge contracts and routes
 must be populated only after audit approval and mainnet deployment.

--- a/MultX/signer/src/index.js
+++ b/MultX/signer/src/index.js
@@ -1,8 +1,14 @@
 import fs from 'fs';
 import https from 'https';
-import path from 'path';
 import { ethers } from 'ethers';
-import { assertLockEvent, releaseMessageHash, resolvePolicy, validateAttestation } from './policy.js';
+import { createDecisionJournal } from './journal.js';
+import {
+  assertLockEvent,
+  parseSignerPolicy,
+  releaseMessageHash,
+  resolvePolicy,
+  validateAttestation,
+} from './policy.js';
 
 const requiredFile = (envName) => {
   const file = process.env[envName];
@@ -12,7 +18,7 @@ const requiredFile = (envName) => {
   return value;
 };
 
-const policy = JSON.parse(requiredFile('SIGNER_POLICY_FILE').toString('utf8'));
+const policy = parseSignerPolicy(JSON.parse(requiredFile('SIGNER_POLICY_FILE').toString('utf8')));
 const privateKey = requiredFile('SIGNER_PRIVATE_KEY_FILE').toString('utf8').trim();
 const wallet = new ethers.Wallet(privateKey);
 if (policy.signerAddress && ethers.getAddress(policy.signerAddress) !== wallet.address) {
@@ -23,7 +29,9 @@ const providers = new Map();
 const sourceContract = (source) => {
   const key = Number(source.chainId);
   if (!providers.has(key)) {
-    const provider = new ethers.JsonRpcProvider(source.rpcUrl, key, { staticNetwork: true });
+    // Do not pin a static network here: getNetwork() must query the endpoint so
+    // a policy URL that is accidentally pointed at another chain fails closed.
+    const provider = new ethers.JsonRpcProvider(source.rpcUrl);
     const contract = new ethers.Contract(source.bridgeAddress, [
       'event TokensLocked(bytes32 indexed txHash,address indexed token,address indexed user,uint256 amount,uint256 targetChain,uint256 nonce)',
     ], provider);
@@ -33,27 +41,7 @@ const sourceContract = (source) => {
 };
 
 const stateFile = process.env.SIGNER_STATE_FILE || '/var/lib/multx-signer/signed-releases.jsonl';
-fs.mkdirSync(path.dirname(stateFile), { recursive: true, mode: 0o700 });
-const signed = new Map();
-if (fs.existsSync(stateFile)) {
-  for (const line of fs.readFileSync(stateFile, 'utf8').split('\n').filter(Boolean)) {
-    const record = JSON.parse(line);
-    const prior = signed.get(record.key);
-    if (prior && prior !== record.hash) throw new Error(`equivocation detected in state for ${record.key}`);
-    signed.set(record.key, record.hash);
-  }
-}
-
-const persistDecision = (key, hash) => {
-  const fd = fs.openSync(stateFile, 'a', 0o600);
-  try {
-    fs.writeSync(fd, `${JSON.stringify({ key, hash, at: new Date().toISOString() })}\n`);
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
-  signed.set(key, hash);
-};
+const journal = createDecisionJournal(stateFile);
 
 let signingQueue = Promise.resolve();
 const serializeSigning = (fn) => {
@@ -71,7 +59,7 @@ const verifyAndSign = async (input) => {
   if (Number(network.chainId) !== attestation.sourceChain) throw new Error('source RPC chain ID mismatch');
   const tip = await provider.getBlockNumber();
   const confirmations = tip - attestation.sourceBlock + 1;
-  if (confirmations < Number(source.confirmations || 1)) {
+  if (confirmations < source.confirmations) {
     throw new Error(`source lock has ${confirmations} confirmations`);
   }
 
@@ -88,11 +76,10 @@ const verifyAndSign = async (input) => {
   const hash = releaseMessageHash(attestation);
   const key = `${attestation.sourceChain}:${attestation.sourceNonce}`;
   return serializeSigning(async () => {
-    const prior = signed.get(key);
-    if (prior && prior !== hash) throw new Error(`refusing equivocation for ${key}`);
-    const signature = await wallet.signMessage(ethers.getBytes(hash));
-    if (!prior) persistDecision(key, hash);
-    return signature;
+    // Persist the decision before producing a signature. A crash can therefore
+    // withhold a signature, but can never erase the anti-equivocation decision.
+    journal.record(key, hash);
+    return wallet.signMessage(ethers.getBytes(hash));
   });
 };
 
@@ -143,7 +130,15 @@ const server = https.createServer({
   }
 });
 
+server.headersTimeout = 10_000;
+server.requestTimeout = 15_000;
+server.keepAliveTimeout = 5_000;
+server.maxRequestsPerSocket = 100;
+
 const port = Number(process.env.SIGNER_PORT || 9443);
+if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+  throw new Error('SIGNER_PORT must be an integer between 1 and 65535');
+}
 server.listen(port, '0.0.0.0', () => {
   console.log(`[signer] listening on ${port}; address=${wallet.address}`);
 });

--- a/MultX/signer/src/journal.js
+++ b/MultX/signer/src/journal.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+export function createDecisionJournal(stateFile) {
+  const directory = path.dirname(stateFile);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+
+  const decisions = new Map();
+  if (fs.existsSync(stateFile)) {
+    const stat = fs.lstatSync(stateFile);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error('signing journal must be a regular file, not a symlink');
+    }
+    fs.chmodSync(stateFile, 0o600);
+    for (const [index, line] of fs.readFileSync(stateFile, 'utf8').split('\n').filter(Boolean).entries()) {
+      let record;
+      try { record = JSON.parse(line); }
+      catch { throw new Error(`invalid JSON in signing journal line ${index + 1}`); }
+      if (!/^[1-9][0-9]*:[1-9][0-9]*$/.test(record?.key || '') ||
+          !/^0x[0-9a-fA-F]{64}$/.test(record?.hash || '')) {
+        throw new Error(`invalid signing journal record at line ${index + 1}`);
+      }
+      const prior = decisions.get(record.key);
+      if (prior && prior !== record.hash) throw new Error(`equivocation detected in state for ${record.key}`);
+      decisions.set(record.key, record.hash);
+    }
+  }
+
+  return {
+    record(key, hash) {
+      if (!/^[1-9][0-9]*:[1-9][0-9]*$/.test(key) || !/^0x[0-9a-fA-F]{64}$/.test(hash)) {
+        throw new Error('invalid signing journal decision');
+      }
+      const prior = decisions.get(key);
+      if (prior && prior !== hash) throw new Error(`refusing equivocation for ${key}`);
+      if (prior) return false;
+
+      const fd = fs.openSync(stateFile, 'a', 0o600);
+      try {
+        fs.writeSync(fd, `${JSON.stringify({ key, hash, at: new Date().toISOString() })}\n`);
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+      decisions.set(key, hash);
+      return true;
+    },
+  };
+}

--- a/MultX/signer/src/policy.js
+++ b/MultX/signer/src/policy.js
@@ -13,6 +13,81 @@ const safePositiveInteger = (value, label) => {
   return number;
 };
 
+const nonZeroAddress = (value, label) => {
+  const address = ethers.getAddress(value || '');
+  if (address === ethers.ZeroAddress) throw new Error(`${label} must be non-zero`);
+  return address;
+};
+
+const rpcUrl = (value, label) => {
+  let url;
+  try { url = new URL(value); } catch { throw new Error(`${label} must be a valid URL`); }
+  const loopback = ['localhost', '127.0.0.1', '::1'].includes(url.hostname);
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+    throw new Error(`${label} must use HTTPS (HTTP is allowed only for loopback rehearsal)`);
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${label} must not contain credentials, query parameters, or a fragment`);
+  }
+  return url.toString();
+};
+
+export const parseSignerPolicy = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('signer policy must be an object');
+  }
+  if (!Array.isArray(input.sources) || input.sources.length === 0) {
+    throw new Error('signer policy must contain at least one source');
+  }
+
+  const chainIds = new Set();
+  const sources = input.sources.map((rawSource, sourceIndex) => {
+    const label = `sources[${sourceIndex}]`;
+    const chainId = safePositiveInteger(rawSource?.chainId, `${label}.chainId`);
+    if (chainIds.has(chainId)) throw new Error(`${label}.chainId duplicates an earlier source`);
+    chainIds.add(chainId);
+    if (!Array.isArray(rawSource.routes) || rawSource.routes.length === 0) {
+      throw new Error(`${label}.routes must contain at least one route`);
+    }
+
+    const routeKeys = new Set();
+    const routes = rawSource.routes.map((rawRoute, routeIndex) => {
+      const routeLabel = `${label}.routes[${routeIndex}]`;
+      const route = {
+        sourceToken: nonZeroAddress(rawRoute?.sourceToken, `${routeLabel}.sourceToken`),
+        targetChain: safePositiveInteger(rawRoute?.targetChain, `${routeLabel}.targetChain`),
+        releaseToken: nonZeroAddress(rawRoute?.releaseToken, `${routeLabel}.releaseToken`),
+        releaseBridge: nonZeroAddress(rawRoute?.releaseBridge, `${routeLabel}.releaseBridge`),
+      };
+      // A source lock binds only sourceToken + targetChain. That pair must map
+      // to exactly one release token/bridge or a requester could choose between
+      // multiple policy-approved release outcomes for the same lock event.
+      const key = [route.sourceToken, route.targetChain]
+        .map(String)
+        .join(':')
+        .toLowerCase();
+      if (routeKeys.has(key)) throw new Error(`${routeLabel} duplicates an earlier route`);
+      routeKeys.add(key);
+      return route;
+    });
+
+    return {
+      chainId,
+      rpcUrl: rpcUrl(rawSource.rpcUrl, `${label}.rpcUrl`),
+      bridgeAddress: nonZeroAddress(rawSource.bridgeAddress, `${label}.bridgeAddress`),
+      confirmations: safePositiveInteger(rawSource.confirmations, `${label}.confirmations`),
+      routes,
+    };
+  });
+
+  return {
+    ...(input.signerAddress
+      ? { signerAddress: nonZeroAddress(input.signerAddress, 'signerAddress') }
+      : {}),
+    sources,
+  };
+};
+
 export const validateAttestation = (input) => ({
   version: Number(input?.version),
   sourceTxHash: /^0x[0-9a-fA-F]{64}$/.test(input?.sourceTxHash || '')
@@ -21,11 +96,11 @@ export const validateAttestation = (input) => ({
   sourceChain: safePositiveInteger(input?.sourceChain, 'sourceChain'),
   sourceNonce: positiveIntegerString(input?.sourceNonce, 'sourceNonce'),
   sourceBlock: safePositiveInteger(input?.sourceBlock, 'sourceBlock'),
-  sourceBridge: ethers.getAddress(input?.sourceBridge || ''),
-  sourceToken: ethers.getAddress(input?.sourceToken || ''),
-  releaseToken: ethers.getAddress(input?.releaseToken || ''),
-  releaseBridge: ethers.getAddress(input?.releaseBridge || ''),
-  user: ethers.getAddress(input?.user || ''),
+  sourceBridge: nonZeroAddress(input?.sourceBridge, 'sourceBridge'),
+  sourceToken: nonZeroAddress(input?.sourceToken, 'sourceToken'),
+  releaseToken: nonZeroAddress(input?.releaseToken, 'releaseToken'),
+  releaseBridge: nonZeroAddress(input?.releaseBridge, 'releaseBridge'),
+  user: nonZeroAddress(input?.user, 'user'),
   amount: positiveIntegerString(input?.amount, 'amount'),
   targetChain: safePositiveInteger(input?.targetChain, 'targetChain'),
 });

--- a/MultX/signer/test/journal.test.js
+++ b/MultX/signer/test/journal.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { createDecisionJournal } from '../src/journal.js';
+
+test('persists a signing decision before reuse and rejects equivocation after restart', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'multx-journal-'));
+  const stateFile = path.join(directory, 'decisions.jsonl');
+  try {
+    const first = createDecisionJournal(stateFile);
+    const firstHash = `0x${'aa'.repeat(32)}`;
+    const conflictingHash = `0x${'bb'.repeat(32)}`;
+    assert.equal(first.record('9005:7', firstHash), true);
+    assert.equal(first.record('9005:7', firstHash), false);
+
+    const restored = createDecisionJournal(stateFile);
+    assert.equal(restored.record('9005:7', firstHash), false);
+    assert.throws(() => restored.record('9005:7', conflictingHash), /refusing equivocation/);
+    assert.equal(fs.readFileSync(stateFile, 'utf8').trim().split('\n').length, 1);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('fails closed on a corrupt journal', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'multx-journal-'));
+  const stateFile = path.join(directory, 'decisions.jsonl');
+  try {
+    fs.writeFileSync(stateFile, '{not-json}\n', { mode: 0o600 });
+    assert.throws(() => createDecisionJournal(stateFile), /invalid JSON/);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('rejects malformed journal decisions', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'multx-journal-'));
+  const stateFile = path.join(directory, 'decisions.jsonl');
+  try {
+    const journal = createDecisionJournal(stateFile);
+    assert.throws(() => journal.record('9005:0', `0x${'aa'.repeat(32)}`), /invalid signing journal/);
+    assert.throws(() => journal.record('9005:7', 'not-a-hash'), /invalid signing journal/);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/MultX/signer/test/policy.test.js
+++ b/MultX/signer/test/policy.test.js
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ethers } from 'ethers';
-import { releaseMessageHash, resolvePolicy, validateAttestation } from '../src/policy.js';
+import {
+  parseSignerPolicy,
+  releaseMessageHash,
+  resolvePolicy,
+  validateAttestation,
+} from '../src/policy.js';
 
 const input = {
   version: 1,
@@ -21,7 +26,9 @@ const input = {
 const policy = {
   sources: [{
     chainId: 9005,
+    rpcUrl: 'https://rpc-mainnet.litho.ai',
     bridgeAddress: input.sourceBridge,
+    confirmations: 12,
     routes: [{
       sourceToken: input.sourceToken,
       targetChain: 1,
@@ -33,8 +40,66 @@ const policy = {
 
 test('accepts an allowlisted source bridge and token route', () => {
   const attestation = validateAttestation(input);
-  assert.equal(resolvePolicy(policy, attestation).source.chainId, 9005);
+  const parsed = parseSignerPolicy(policy);
+  assert.equal(resolvePolicy(parsed, attestation).source.chainId, 9005);
   assert.match(releaseMessageHash(attestation), /^0x[0-9a-f]{64}$/);
+});
+
+test('rejects missing, malformed, and zero confirmation policy', () => {
+  const source = policy.sources[0];
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [{ ...source, confirmations: undefined }] }),
+    /confirmations must be a positive integer/,
+  );
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [{ ...source, confirmations: 'not-a-number' }] }),
+    /confirmations must be a positive integer/,
+  );
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [{ ...source, confirmations: 0 }] }),
+    /confirmations must be a positive integer/,
+  );
+});
+
+test('rejects unsafe RPC URLs, duplicate sources, and duplicate routes', () => {
+  const source = policy.sources[0];
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [{ ...source, rpcUrl: 'http://rpc.example.test' }] }),
+    /must use HTTPS/,
+  );
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [source, source] }),
+    /duplicates an earlier source/,
+  );
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [{ ...source, routes: [source.routes[0], source.routes[0]] }] }),
+    /duplicates an earlier route/,
+  );
+  assert.throws(
+    () => parseSignerPolicy({
+      ...policy,
+      sources: [{
+        ...source,
+        routes: [source.routes[0], {
+          ...source.routes[0],
+          releaseToken: ethers.Wallet.createRandom().address,
+        }],
+      }],
+    }),
+    /duplicates an earlier route/,
+  );
+});
+
+test('rejects zero critical addresses in policy and attestations', () => {
+  const source = policy.sources[0];
+  assert.throws(
+    () => parseSignerPolicy({ ...policy, sources: [{ ...source, bridgeAddress: ethers.ZeroAddress }] }),
+    /must be non-zero/,
+  );
+  assert.throws(
+    () => validateAttestation({ ...input, user: ethers.ZeroAddress }),
+    /must be non-zero/,
+  );
 });
 
 test('rejects a release token not in signer policy', () => {

--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -50,7 +50,7 @@ into a reviewable change, and never bulk-commit the dirty worktree.
 | MX-03 | Thanos Wallet | Repository work merged and deployed; acceptance open | EXTERNAL BLOCKER | Wallet team completes the published-version browser matrix, signed transaction, and approval record. |
 | MX-04 | DNNS | Verified explorer hardening merged and deployed; owner acceptance open | EXTERNAL BLOCKER | DNNS owner confirms the supported interface, fixes public docs, nominates a reverse record, and accepts cache policy. |
 | MX-05 | Quantt | Assumption-free gates deployed; adapter remains disabled | EXTERNAL BLOCKER | Quantt owner supplies the API contract/credential and fixes or replaces the development TLS endpoint. |
-| MX-01 | MultX / Lithoswap | Bridge and hardened V2 DEX source merged; AWS proposal closed; swap disabled | IN PROGRESS | Review the existing provider-neutral signer, then obtain independent audit, deployment, controller, and liquidity approvals. |
+| MX-01 | MultX / Lithoswap | V2 DEX merged; non-AWS signer hardening under review; swap disabled | IN PROGRESS | Merge signer fail-closed fixes, then obtain independent audit, operator, deployment, controller, and liquidity approvals. |
 | MX-07 | Developer toolchain | Expanded v0 local-only; no deployable compiler/release | IN PROGRESS, LOCAL ONLY | Review local tools, then implement compiler lowering/codegen and conformance. |
 
 ## Sequential closure queue
@@ -103,14 +103,18 @@ Completed or evidenced:
       `07b37969f00d97eaca17794c31a83546b60a1940`; no deployment or funding occurred (2026-08-16).
 - [x] AWS-specific PR #78 was reverified unchanged and closed as rejected architecture; no signer deployment or
       production configuration change occurred (2026-08-16).
+- [x] Local provider-neutral signer review added strict policy/RPC validation, journal-before-sign semantics, unique
+      quorum identities, serialized polling, configured-signer-only counts, and explicit multichain evidence gates.
+- [x] Eleven signer tests, eighteen API tests, and eighty-eight bridge-contract tests pass; all three production
+      dependency audits report zero vulnerabilities locally (2026-08-16).
 
 Remaining actions:
 
 - [x] Isolate, review, and merge the V2 contracts, release-gated deployment/liquidity scripts, and tests in PR #68.
 - [ ] Separately review the optional V2 subgraph only if analytics are required. It is not required for quotes or swaps.
 - [x] Close PR #78's AWS-specific signer proposal; AWS KMS/IAM is not an accepted project dependency.
-- [ ] Review and operationally accept the provider-neutral VPS signer/quorum already on `main`, including key custody,
-      host hardening, monitoring, failure behavior, and rollback before any privileged deployment.
+- [ ] Merge the provider-neutral signer/API review hardening, then complete independent and operator acceptance,
+      including key custody, host hardening, monitoring, failure behavior, recovery, and rollback before deployment.
 - [ ] Modernize or explicitly disposition the MultX deployment/test toolchain's transitive audit findings before
       using it as a long-lived privileged runner (full local audit: 3 critical, 14 high; production-only audit: 0).
 - [ ] Obtain Backend/Bridge confirmation of the route contract, token map, relayer/claim behavior, and supported
@@ -145,6 +149,8 @@ Evidence:
 - `Makalu/contracts/scripts/dex-e2e.ts`
 - `docs/dex-team-request-lithoswap.md`
 - `MultX/docs/V05_TESTNET_REDEPLOYMENT.md`
+- `MultX/docs/VPS_SIGNER_ARCHITECTURE.md`
+- `MultX/signer/OPERATOR_RUNBOOK.md`
 - Review PR: `https://github.com/KaJLabs/Lithosphere/pull/75`
 - Lithoswap V2 PR: `https://github.com/KaJLabs/Lithosphere/pull/68`
 - Blocked AWS proposal: `https://github.com/KaJLabs/Lithosphere/pull/78`
@@ -602,8 +608,26 @@ Evidence:
 | 2026-08-15 | MultX toolchain audit | PARTIAL | `npm audit --omit=dev` reports zero; full operational/test dependency audit reports 3 critical and 14 high transitive findings. |
 | 2026-08-16 | Lithoswap V2 repository review | MERGED | PR #68 passed every repository check and merged as `07b37969`; current-main build, 28 full Hardhat tests, 23 focused DEX/configuration tests, nine E2E checks, strict TypeScript, and Slither with zero detectors passed. No deployment or funding occurred. |
 | 2026-08-16 | Lithoswap V2 toolchain audit | PARTIAL | Contract package has no production runtime dependencies; its Hardhat/test-only dependency graph reports 1 critical, 55 high, 43 moderate, and 10 low transitive advisories. |
+| 2026-08-16 | Provider-neutral signer review | PASS, LOCAL | 11 signer, 18 API, and 88 bridge-contract tests pass; all three production dependency audits report zero. Fail-closed policy, live RPC chain-ID verification, journal, quorum, poll serialization, URL, explicit-evidence, and unique on-chain validator fixes await PR review. |
 
 ## Change log
+
+### 2026-08-16 — MX-01 provider-neutral signer review hardened locally
+
+- Verified the EIP-191 message domain matches both destination contracts, the API verifier, and release executor.
+- Closed malformed-policy confirmation bypasses and rejected insecure/credential-bearing RPC and signer URLs,
+  duplicate sources/routes, and zero critical addresses.
+- Removed the static-network trust shortcut so the signer verifies the RPC's reported chain ID.
+- Changed anti-equivocation handling to fsync the decision before signing; added restart and corrupt-journal tests.
+- Rejected duplicate signer identities and invalid timeouts, serialized signing polls, counted only distinct current
+  configured signer addresses, and removed implicit source-chain/release-token fallbacks.
+- Made both bridge implementations reject duplicate validator identities at deployment and during rotation.
+- Updated status/signature responses to expose the configured threshold, distinct counts, and deterministic lowercase
+  signer ordering.
+- Signer: 11 tests pass; API: 18 tests pass; bridge contracts: 88 tests pass; all three production dependency audits
+  report zero vulnerabilities.
+- No signer was deployed, no key was accessed, and no production configuration was changed.
+- Updated by: `bachal-mb`.
 
 ### 2026-08-16 — MX-01 Lithoswap V2 repository slice merged
 


### PR DESCRIPTION
## Summary
- fail closed on malformed signer policy, unsafe RPC/signer URLs, wrong RPC chain IDs, ambiguous routes, incomplete lock evidence, duplicate identities, and invalid quorum settings
- persist and fsync anti-equivocation decisions before signing; reject corrupt/malformed journals across restart
- serialize signing polls and count/serve only distinct signatures from the current configured signer set
- reject duplicate on-chain validator identities in both bridge constructors and rotations
- record verified MX-01 state in the Makalu extra-work tracker

## Verification
- `MultX/signer`: 11 tests pass; `npm audit --omit=dev`: 0 vulnerabilities
- `MultX/api`: 18 tests pass; `npm audit --omit=dev`: 0 vulnerabilities
- `MultX/contracts`: 88 tests pass; `npm audit --omit=dev`: 0 vulnerabilities
- changed JavaScript syntax checks pass
- `git diff --check` passes

## Operational scope
Review/source hardening only. No signer or contract deployment, key access, funding, feature enablement, or production configuration change was performed. Swap remains disabled pending independent audit and explicit operator/controller/liquidity approvals.