### PR TITLE
feat(toolchain): add conservative lithc checks

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -1,0 +1,48 @@
+name: Lithic Toolchain CI
+
+on:
+  push:
+    paths:
+      - "toolchain/**"
+      - ".github/workflows/ci-toolchain.yaml"
+  pull_request:
+    paths:
+      - "toolchain/**"
+      - ".github/workflows/ci-toolchain.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: toolchain
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
+      - name: Select Rust toolchain
+        run: rustup default stable
+      - name: Formatting (reviewed front-end slice)
+        run: >-
+          rustfmt --check --edition 2021
+          crates/lithic-syntax/src/lib.rs
+          crates/lithic-syntax/src/sema.rs
+          crates/lithc/src/main.rs
+          crates/lithc/tests/cli.rs
+      - name: Lints (reviewed front-end slice)
+        run: cargo clippy -p lithic-syntax -p lithc --all-targets -- -D warnings
+      - name: Tests
+        run: cargo test --workspace
+      - name: Release build
+        run: cargo build --workspace --release
+      - name: lithc check smoke test
+        run: cargo run -p lithc -- --emit check ../Makalu/contracts/src/DOGE.lithic

--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -51,7 +51,7 @@ into a reviewable change, and never bulk-commit the dirty worktree.
 | MX-04 | DNNS | Verified explorer hardening merged and deployed; owner acceptance open | EXTERNAL BLOCKER | DNNS owner confirms the supported interface, fixes public docs, nominates a reverse record, and accepts cache policy. |
 | MX-05 | Quantt | Assumption-free gates deployed; adapter remains disabled | EXTERNAL BLOCKER | Quantt owner supplies the API contract/credential and fixes or replaces the development TLS endpoint. |
 | MX-01 | MultX / Lithoswap | V2 DEX and non-AWS signer hardening merged; swap disabled | IN PROGRESS | Obtain independent audit, operator, deployment, controller, and liquidity approvals. |
-| MX-07 | Developer toolchain | Expanded v0 local-only; no deployable compiler/release | IN PROGRESS, LOCAL ONLY | Review local tools, then implement compiler lowering/codegen and conformance. |
+| MX-07 | Developer toolchain | First compiler-front-end review slice isolated; no deployable compiler/release | IN PROGRESS, LOCAL ONLY | Merge conservative declaration checks and three-OS CI, then review each remaining tool separately. |
 
 ## Sequential closure queue
 
@@ -495,13 +495,16 @@ Evidence:
 **Owners:** Lithic/compiler team + Dev Infra/release owner + Security reviewer
 
 **Current state:** The workspace expands all eight public tools into functional v0 implementations and adds three-OS
-CI/release packaging. Those changes remain local-only. The tracked `main` version still describes `lithls`, `lithdev`,
-`lithtest`, `lithsec`, and `lithpkg` as spec-only stubs. Even in the local implementation, `lithc` stops after parsing,
-semantic checks, AST/ABI output; it does not parse/lower full function bodies into deployable LithoVM/EVM bytecode.
+CI/release packaging. Those changes remain local-only. Review of the first shared-syntax/`lithc` slice found that the
+local semantic pass inferred an unapproved primitive-type table, overload behavior, map-key restrictions, and return
+semantics. The isolated review candidate removes those assumptions, adds only unambiguous declaration-name checks,
+and introduces a three-OS CI gate. The tracked release still describes `lithls`, `lithdev`, `lithtest`, `lithsec`, and
+`lithpkg` as spec-only stubs. `lithc` still does not parse/lower full function bodies into deployable LithoVM/EVM
+bytecode.
 
 | Tool | Local implementation | Required before full-release acceptance |
 | --- | --- | --- |
-| `lithc` | Lexer, declarations, semantic/name/type checks, AST/ABI/check output. | Full statements/expressions, typed IR, deterministic bytecode/codegen, source maps, diagnostics, and conformance tests. |
+| `lithc` | Lexer/parser and AST/ABI output; conservative declaration-check candidate under review. | Approved type/overload/map/return semantics, full statements/expressions, typed IR, deterministic bytecode/codegen, source maps, diagnostics, and conformance tests. |
 | `lithfmt` | Parse-safe whitespace normalization and `--check`. | Decide whether v0 is accepted or implement AST-driven canonical formatting/idempotence corpus. |
 | `lithlint` | AST-driven L001–L004 rules and warning denial. | Rule/version policy, suppression/config behavior, false-positive corpus, and release documentation. |
 | `lithls` | Stdio LSP lifecycle, full sync, diagnostics, and document symbols. | Editor acceptance; decide whether incremental sync, completion, hover, and go-to-definition are release gates. |
@@ -517,10 +520,19 @@ Completed or evidenced locally:
 - [x] Local `cargo fmt --check` and Clippy with warnings denied pass (2026-08-03).
 - [x] A three-OS CI workflow and release-archive changes exist locally.
 - [x] The July readiness run recorded 29 Rust tests and a release build passing in an environment with a linker.
+- [x] Inventoried the 1,700+ line local multi-tool change and isolated shared syntax/`lithc` rather than bulk-committing
+      unrelated tools (2026-08-16).
+- [x] Removed unapproved type, overload, map-key, and return assumptions from the first review candidate; added
+      conservative duplicate const/state-field/parameter checks plus `lithc --emit check`.
+- [x] Local targeted rustfmt, workspace `cargo check`, and Clippy with warnings denied for the reviewed crates pass.
+- [x] Added a three-OS CI candidate to run scoped formatting/Clippy, full workspace tests/release build, and a real
+      `lithc` smoke check.
 
 Remaining actions:
 
-- [ ] Split and review the shared syntax/sema changes, each public tool, CI, release packaging, examples, and lockfile.
+- [ ] Merge the reviewed shared syntax/`lithc` and CI slice after its Linux/Windows/macOS gates pass.
+- [ ] Separately review `lithfmt`, `lithlint`, `lithls`, `lithdev`, `lithtest`, `lithsec`, `lithpkg`, release packaging,
+      examples, and lockfile.
 - [ ] Run the full workspace tests/release build on Linux, Windows, and macOS. The 2026-08-03 Windows audit host lacks
       `link.exe`, so it could lint/check but could not link Rust test binaries.
 - [ ] Specify full function-body grammar, semantics, ABI/bytecode compatibility target, and compiler conformance
@@ -615,8 +627,21 @@ Evidence:
 | 2026-08-16 | Lithoswap V2 repository review | MERGED | PR #68 passed every repository check and merged as `07b37969`; current-main build, 28 full Hardhat tests, 23 focused DEX/configuration tests, nine E2E checks, strict TypeScript, and Slither with zero detectors passed. No deployment or funding occurred. |
 | 2026-08-16 | Lithoswap V2 toolchain audit | PARTIAL | Contract package has no production runtime dependencies; its Hardhat/test-only dependency graph reports 1 critical, 55 high, 43 moderate, and 10 low transitive advisories. |
 | 2026-08-16 | Provider-neutral signer review | MERGED | PR #93 passed all checks and merged as `60f3f7bb`; 11 signer, 18 API, and 88 bridge-contract tests pass; all three production dependency audits report zero. No deployment or key access occurred. |
+| 2026-08-16 | Toolchain shared front-end review | PASS, LOCAL | Local multi-tool work was split; speculative language rules were rejected. Targeted rustfmt, workspace check, and reviewed-crate Clippy pass. Three-OS tests/build await PR CI. |
 
 ## Change log
+
+### 2026-08-16 — MX-07 shared front-end review isolated
+
+- Inventoried the uncommitted toolchain work without modifying the original dirty workspace and isolated the shared
+  syntax/`lithc` slice from the other tools, examples, lockfile, and release packaging.
+- Rejected the local semantic pass's unapproved primitive-type, overload, map-key, and return assumptions.
+- Added only conservative duplicate const, state-field, and parameter checks plus an honest `lithc --emit check`
+  mode that does not claim full type checking or code generation.
+- Added Linux/Windows/macOS CI for scoped format/Clippy, full workspace tests and release build, and a compiler smoke
+  test. Local targeted rustfmt, workspace check, and reviewed-crate Clippy pass; hosted linker-backed CI is pending.
+- No compiler release or deployable bytecode is claimed or published.
+- Updated by: `bachal-mb`.
 
 ### 2026-08-16 — MX-01 provider-neutral signer hardening merged
 

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -12,7 +12,7 @@ the parser is tested against as golden files.
 
 | Tool       | Status        | What it does today |
 |------------|---------------|--------------------|
-| `lithc`    | **real (front-end)** | Lex + parse `.lithic`, report diagnostics, `--emit summary\|ast\|abi`. Type-checking and bytecode codegen are next. |
+| `lithc`    | **real (front-end)** | Lex + parse `.lithic`, reject unambiguous declaration-name collisions, and support `--emit summary\|ast\|abi\|check`. Full type checking and bytecode codegen are next. |
 | `lithfmt`  | **real (v0)** | Safe whitespace normalisation (tabs→spaces, strip trailing, single trailing newline); refuses to touch files with parse errors. `--check` for CI. |
 | `lithlint` | **real (v0)** | AST-driven lint rules L001–L004 (naming + `@ai_budget` on `pub async fn`). `--deny-warnings` for CI. |
 | `lithls`   | spec-only stub | Language server (LSP). |
@@ -55,7 +55,7 @@ cargo run -p lithfmt -- --check ../Makalu/contracts/src/DOGE.lithic
 
 ## Roadmap (next phases)
 
-1. `lithc`: name resolution + type checking over the declaration AST.
+1. `lithc`: specify and implement name resolution + type checking over the declaration AST. The current conservative pass intentionally does not infer unapproved type, overload, map-key, or return rules.
 2. `lithc`: full statement/expression parsing of function bodies.
 3. `lithc`: lower to LithoVM/EVM bytecode + canonical ABI JSON.
 4. `lithfmt`: AST-driven canonical formatting.

--- a/toolchain/crates/lithc/src/main.rs
+++ b/toolchain/crates/lithc/src/main.rs
@@ -2,8 +2,9 @@
 //!
 //! This scaffold implements the compiler front-end: it lexes and parses a
 //! `.lithic` source file, reports diagnostics, and emits either a human
-//! summary, the declaration AST as JSON, or a Lithic ABI as JSON. Type
-//! checking and LithoVM bytecode codegen are the next phases (see README).
+//! summary, the declaration AST as JSON, or a Lithic ABI as JSON. It performs
+//! conservative declaration checks, while full type checking and LithoVM
+//! bytecode codegen remain future phases (see README).
 
 use std::process::exit;
 
@@ -15,15 +16,16 @@ USAGE:\n\
     lithc [OPTIONS] <FILE.lithic>\n\
 \n\
 OPTIONS:\n\
-    --emit <KIND>   Output kind: summary (default), ast, abi\n\
+    --emit <KIND>   Output kind: summary (default), ast, abi, check\n\
     -h, --help      Print this help\n\
 \n\
 EXAMPLES:\n\
     lithc Makalu/contracts/src/DOGE.lithic\n\
     lithc --emit abi DOGE.lithic\n\
-    lithc --emit ast DOGE.lithic\n\
+    lithc --emit check DOGE.lithic\n\
 \n\
-NOTE: type checking and LithoVM bytecode emission are not yet implemented.",
+NOTE: check validates parsing and unambiguous declaration-name collisions.\n\
+Full type checking and LithoVM bytecode emission are not yet implemented.",
         env!("CARGO_PKG_VERSION")
     );
 }
@@ -95,12 +97,29 @@ fn main() {
         exit(1);
     }
 
+    let findings = lithic_syntax::check(&contract);
+    for finding in &findings {
+        eprintln!("{}", finding.render(&path));
+    }
+    let declaration_errors = lithic_syntax::sema::error_count(&findings);
+    if declaration_errors > 0 {
+        eprintln!(
+            "lithc: aborting due to {} declaration error(s)",
+            declaration_errors
+        );
+        exit(1);
+    }
+
     match emit.as_str() {
+        "check" => eprintln!("{}: declaration checks clean", path),
         "summary" => print!("{}", contract.summary()),
         "ast" => println!("{}", contract.to_json()),
         "abi" => println!("{}", contract.to_abi_json()),
         other => {
-            eprintln!("lithc: error: unknown emit kind '{}' (expected summary|ast|abi)", other);
+            eprintln!(
+                "lithc: error: unknown emit kind '{}' (expected summary|ast|abi|check)",
+                other
+            );
             exit(2);
         }
     }

--- a/toolchain/crates/lithc/tests/cli.rs
+++ b/toolchain/crates/lithc/tests/cli.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn source_file(label: &str, source: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "lithc-{label}-{}-{nonce}.lithic",
+        std::process::id()
+    ));
+    fs::write(&path, source).expect("write Lithic fixture");
+    path
+}
+
+#[test]
+fn check_mode_accepts_a_clean_contract() {
+    let path = source_file("clean", "contract C { state { value: u256; } }");
+    let output = Command::new(env!("CARGO_BIN_EXE_lithc"))
+        .args(["--emit", "check"])
+        .arg(&path)
+        .output()
+        .expect("run lithc");
+    fs::remove_file(&path).expect("remove Lithic fixture");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("declaration checks clean"));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn check_mode_rejects_an_unambiguous_name_collision() {
+    let path = source_file(
+        "duplicate",
+        "contract C { state { value: u256; } state { value: bool; } }",
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_lithc"))
+        .args(["--emit", "check"])
+        .arg(&path)
+        .output()
+        .expect("run lithc");
+    fs::remove_file(&path).expect("remove Lithic fixture");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[E002] duplicate state field `value`"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("aborting due to 1 declaration error(s)"));
+}

--- a/toolchain/crates/lithic-syntax/src/ast.rs
+++ b/toolchain/crates/lithic-syntax/src/ast.rs
@@ -98,14 +98,26 @@ impl Contract {
     pub fn consts(&self) -> Vec<&ConstDecl> {
         self.items
             .iter()
-            .filter_map(|i| if let Item::Const(c) = i { Some(c) } else { None })
+            .filter_map(|i| {
+                if let Item::Const(c) = i {
+                    Some(c)
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
     pub fn events(&self) -> Vec<&EventDecl> {
         self.items
             .iter()
-            .filter_map(|i| if let Item::Event(e) = i { Some(e) } else { None })
+            .filter_map(|i| {
+                if let Item::Event(e) = i {
+                    Some(e)
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
@@ -124,7 +136,13 @@ impl Contract {
     pub fn state_field_count(&self) -> usize {
         self.items
             .iter()
-            .filter_map(|i| if let Item::State(s) = i { Some(s.fields.len()) } else { None })
+            .filter_map(|i| {
+                if let Item::State(s) = i {
+                    Some(s.fields.len())
+                } else {
+                    None
+                }
+            })
             .sum()
     }
 
@@ -140,16 +158,31 @@ impl Contract {
         for f in funcs {
             let vis = if f.is_pub { "pub " } else { "" };
             let asy = if f.is_async { "async " } else { "" };
-            let params: Vec<String> =
-                f.params.iter().map(|p| format!("{}: {}", p.name, p.ty.render())).collect();
-            let ret = f.ret.as_ref().map(|t| format!(" -> {}", t.render())).unwrap_or_default();
+            let params: Vec<String> = f
+                .params
+                .iter()
+                .map(|p| format!("{}: {}", p.name, p.ty.render()))
+                .collect();
+            let ret = f
+                .ret
+                .as_ref()
+                .map(|t| format!(" -> {}", t.render()))
+                .unwrap_or_default();
             let attrs = if f.attrs.is_empty() {
                 String::new()
             } else {
                 let names: Vec<String> = f.attrs.iter().map(|a| format!("@{}", a.name)).collect();
                 format!("{} ", names.join(" "))
             };
-            s.push_str(&format!("    {}{}{}fn {}({}){}\n", attrs, vis, asy, f.name, params.join(", "), ret));
+            s.push_str(&format!(
+                "    {}{}{}fn {}({}){}\n",
+                attrs,
+                vis,
+                asy,
+                f.name,
+                params.join(", "),
+                ret
+            ));
         }
         s
     }
@@ -165,7 +198,13 @@ impl Contract {
             let inputs: Vec<String> = f
                 .params
                 .iter()
-                .map(|p| format!("{{\"name\":\"{}\",\"type\":\"{}\"}}", esc(&p.name), esc(&p.ty.render())))
+                .map(|p| {
+                    format!(
+                        "{{\"name\":\"{}\",\"type\":\"{}\"}}",
+                        esc(&p.name),
+                        esc(&p.ty.render())
+                    )
+                })
                 .collect();
             let outputs = match &f.ret {
                 Some(t) => format!("[{{\"type\":\"{}\"}}]", esc(&t.render())),
@@ -183,7 +222,13 @@ impl Contract {
             let inputs: Vec<String> = e
                 .fields
                 .iter()
-                .map(|fl| format!("{{\"name\":\"{}\",\"type\":\"{}\"}}", esc(&fl.name), esc(&fl.ty.render())))
+                .map(|fl| {
+                    format!(
+                        "{{\"name\":\"{}\",\"type\":\"{}\"}}",
+                        esc(&fl.name),
+                        esc(&fl.ty.render())
+                    )
+                })
                 .collect();
             entries.push(format!(
                 "{{\"type\":\"event\",\"name\":\"{}\",\"inputs\":[{}]}}",
@@ -215,9 +260,19 @@ impl Contract {
                 let fs: Vec<String> = e
                     .fields
                     .iter()
-                    .map(|f| format!("{{\"name\":\"{}\",\"type\":\"{}\"}}", esc(&f.name), esc(&f.ty.render())))
+                    .map(|f| {
+                        format!(
+                            "{{\"name\":\"{}\",\"type\":\"{}\"}}",
+                            esc(&f.name),
+                            esc(&f.ty.render())
+                        )
+                    })
                     .collect();
-                format!("{{\"name\":\"{}\",\"fields\":[{}]}}", esc(&e.name), fs.join(","))
+                format!(
+                    "{{\"name\":\"{}\",\"fields\":[{}]}}",
+                    esc(&e.name),
+                    fs.join(",")
+                )
             })
             .collect();
         let funcs: Vec<String> = self

--- a/toolchain/crates/lithic-syntax/src/diagnostic.rs
+++ b/toolchain/crates/lithic-syntax/src/diagnostic.rs
@@ -29,11 +29,21 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     pub fn error(message: impl Into<String>, lo: usize, hi: usize) -> Self {
-        Diagnostic { severity: Severity::Error, message: message.into(), lo, hi }
+        Diagnostic {
+            severity: Severity::Error,
+            message: message.into(),
+            lo,
+            hi,
+        }
     }
 
     pub fn warning(message: impl Into<String>, lo: usize, hi: usize) -> Self {
-        Diagnostic { severity: Severity::Warning, message: message.into(), lo, hi }
+        Diagnostic {
+            severity: Severity::Warning,
+            message: message.into(),
+            lo,
+            hi,
+        }
     }
 
     pub fn is_error(&self) -> bool {
@@ -43,6 +53,13 @@ impl Diagnostic {
     /// Render as `file:line:col: severity: message`.
     pub fn render(&self, src: &str, filename: &str) -> String {
         let (line, col) = line_col(src, self.lo);
-        format!("{}:{}:{}: {}: {}", filename, line, col, self.severity.label(), self.message)
+        format!(
+            "{}:{}:{}: {}: {}",
+            filename,
+            line,
+            col,
+            self.severity.label(),
+            self.message
+        )
     }
 }

--- a/toolchain/crates/lithic-syntax/src/lexer.rs
+++ b/toolchain/crates/lithic-syntax/src/lexer.rs
@@ -51,7 +51,11 @@ pub fn lex(src: &str) -> Vec<Token> {
             if i < n {
                 i += 1; // closing quote
             }
-            out.push(Token { kind: TokenKind::ByteStr, lo, hi: byte_at(i) });
+            out.push(Token {
+                kind: TokenKind::ByteStr,
+                lo,
+                hi: byte_at(i),
+            });
             continue;
         }
 
@@ -68,7 +72,11 @@ pub fn lex(src: &str) -> Vec<Token> {
             if i < n {
                 i += 1; // closing quote
             }
-            out.push(Token { kind: TokenKind::Str, lo, hi: byte_at(i) });
+            out.push(Token {
+                kind: TokenKind::Str,
+                lo,
+                hi: byte_at(i),
+            });
             continue;
         }
 
@@ -110,14 +118,26 @@ pub fn lex(src: &str) -> Vec<Token> {
                     break;
                 }
             }
-            let kind = if is_float { TokenKind::Float } else { TokenKind::Int };
-            out.push(Token { kind, lo, hi: byte_at(i) });
+            let kind = if is_float {
+                TokenKind::Float
+            } else {
+                TokenKind::Int
+            };
+            out.push(Token {
+                kind,
+                lo,
+                hi: byte_at(i),
+            });
             continue;
         }
 
         // Arrow `->`.
         if c == '-' && i + 1 < n && chars[i + 1].1 == '>' {
-            out.push(Token { kind: TokenKind::Arrow, lo: off, hi: byte_at(i + 2) });
+            out.push(Token {
+                kind: TokenKind::Arrow,
+                lo: off,
+                hi: byte_at(i + 2),
+            });
             i += 2;
             continue;
         }
@@ -141,10 +161,18 @@ pub fn lex(src: &str) -> Vec<Token> {
             '=' => TokenKind::Eq,
             _ => TokenKind::Other,
         };
-        out.push(Token { kind, lo: off, hi: byte_at(i + 1) });
+        out.push(Token {
+            kind,
+            lo: off,
+            hi: byte_at(i + 1),
+        });
         i += 1;
     }
 
-    out.push(Token { kind: TokenKind::Eof, lo: src.len(), hi: src.len() });
+    out.push(Token {
+        kind: TokenKind::Eof,
+        lo: src.len(),
+        hi: src.len(),
+    });
     out
 }

--- a/toolchain/crates/lithic-syntax/src/lib.rs
+++ b/toolchain/crates/lithic-syntax/src/lib.rs
@@ -8,12 +8,14 @@ pub mod ast;
 pub mod diagnostic;
 pub mod lexer;
 pub mod parser;
+pub mod sema;
 pub mod span;
 pub mod token;
 
 pub use ast::{Attr, ConstDecl, Contract, EventDecl, Field, FuncDecl, Item, Param, Type};
 pub use diagnostic::{Diagnostic, Severity};
 pub use parser::{parse, ParseResult};
+pub use sema::{check, Finding, Level};
 
 #[cfg(test)]
 mod tests {

--- a/toolchain/crates/lithic-syntax/src/parser.rs
+++ b/toolchain/crates/lithic-syntax/src/parser.rs
@@ -22,9 +22,17 @@ impl ParseResult {
 
 pub fn parse(src: &str) -> ParseResult {
     let toks = lex(src);
-    let mut p = Parser { src, toks, pos: 0, diags: Vec::new() };
+    let mut p = Parser {
+        src,
+        toks,
+        pos: 0,
+        diags: Vec::new(),
+    };
     let contract = p.parse_contract();
-    ParseResult { contract, diagnostics: p.diags }
+    ParseResult {
+        contract,
+        diagnostics: p.diags,
+    }
 }
 
 struct Parser<'a> {
@@ -188,7 +196,11 @@ impl<'a> Parser<'a> {
         }
         self.eat(K::Semi);
         let value_src = self.src[start..end].trim().to_string();
-        Some(ConstDecl { name, ty, value_src })
+        Some(ConstDecl {
+            name,
+            ty,
+            value_src,
+        })
     }
 
     fn parse_state(&mut self) -> Option<StateBlock> {
@@ -335,7 +347,15 @@ impl<'a> Parser<'a> {
         }
         let body_src = self.src[body_lo..body_hi].to_string();
 
-        Some(FuncDecl { attrs, is_pub, is_async, name, params, ret, body_src })
+        Some(FuncDecl {
+            attrs,
+            is_pub,
+            is_async,
+            name,
+            params,
+            ret,
+            body_src,
+        })
     }
 
     fn parse_type(&mut self) -> Option<Type> {

--- a/toolchain/crates/lithic-syntax/src/sema.rs
+++ b/toolchain/crates/lithic-syntax/src/sema.rs
@@ -1,0 +1,167 @@
+//! Conservative declaration checks for parsed Lithic contracts.
+//!
+//! The repository does not yet contain an approved full Lithic type-system or
+//! function-body specification. This pass therefore checks only name collisions
+//! that are unambiguous in the current declaration AST. It deliberately does
+//! not infer primitive types, overload rules, map-key rules, return semantics,
+//! or any other language behavior that has not been specified.
+
+use crate::ast::{Contract, Item};
+use std::collections::HashSet;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Level {
+    Error,
+}
+
+impl Level {
+    pub fn label(self) -> &'static str {
+        match self {
+            Level::Error => "error",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Finding {
+    pub level: Level,
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl Finding {
+    fn error(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            level: Level::Error,
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.level == Level::Error
+    }
+
+    pub fn render(&self, filename: &str) -> String {
+        format!(
+            "{}: {}: [{}] {}",
+            filename,
+            self.level.label(),
+            self.code,
+            self.message
+        )
+    }
+}
+
+fn report_duplicates<'a>(
+    names: impl Iterator<Item = &'a str>,
+    kind: &str,
+    code: &'static str,
+    findings: &mut Vec<Finding>,
+) {
+    let mut seen = HashSet::new();
+    for name in names {
+        if !seen.insert(name) {
+            findings.push(Finding::error(
+                code,
+                format!("duplicate {} `{}`", kind, name),
+            ));
+        }
+    }
+}
+
+/// Validate declaration-level name collisions supported by the current AST.
+pub fn check(contract: &Contract) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    report_duplicates(
+        contract
+            .consts()
+            .iter()
+            .map(|constant| constant.name.as_str()),
+        "const",
+        "E001",
+        &mut findings,
+    );
+
+    let state_fields = contract.items.iter().filter_map(|item| match item {
+        Item::State(state) => Some(state.fields.as_slice()),
+        _ => None,
+    });
+    report_duplicates(
+        state_fields.flatten().map(|field| field.name.as_str()),
+        "state field",
+        "E002",
+        &mut findings,
+    );
+
+    for function in contract.funcs() {
+        report_duplicates(
+            function.params.iter().map(|param| param.name.as_str()),
+            &format!("parameter of function `{}`", function.name),
+            "E003",
+            &mut findings,
+        );
+    }
+
+    findings
+}
+
+pub fn error_count(findings: &[Finding]) -> usize {
+    findings.iter().filter(|finding| finding.is_error()).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    fn check_source(source: &str) -> Vec<Finding> {
+        let result = parse(source);
+        assert_eq!(
+            result.error_count(),
+            0,
+            "unexpected parser diagnostics: {:?}",
+            result.diagnostics
+        );
+        check(&result.contract.expect("contract"))
+    }
+
+    fn codes(findings: &[Finding]) -> Vec<&str> {
+        findings.iter().map(|finding| finding.code).collect()
+    }
+
+    #[test]
+    fn accepts_unique_declarations() {
+        let findings = check_source(
+            "contract C { const A: bytes32 = 1; state { x: u256; } fn f(a: u256) {} }",
+        );
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn rejects_duplicate_consts() {
+        let findings = check_source("contract C { const A: u256 = 1; const A: u256 = 2; }");
+        assert!(codes(&findings).contains(&"E001"));
+    }
+
+    #[test]
+    fn rejects_duplicate_state_fields_across_blocks() {
+        let findings = check_source("contract C { state { x: u256; } state { x: bool; } }");
+        assert!(codes(&findings).contains(&"E002"));
+    }
+
+    #[test]
+    fn rejects_duplicate_parameters() {
+        let findings = check_source("contract C { fn f(a: u256, a: address) {} }");
+        assert!(codes(&findings).contains(&"E003"));
+    }
+
+    #[test]
+    fn leaves_unapproved_type_and_overload_rules_uninferred() {
+        let findings = check_source(
+            "contract C { state { x: FutureType; } fn f(a: u256) {} fn f(a: address) {} }",
+        );
+        assert!(findings.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- isolate the first MX-07 review slice from the 1,700+ line dirty multi-tool workspace
- add conservative declaration checks for duplicate constants, state fields, and function parameters
- add honest `lithc --emit check` behavior without claiming full type checking or bytecode codegen
- explicitly reject unapproved primitive-type, overload, map-key, and return-semantics assumptions found in the local draft
- add Linux, Windows, and macOS formatting, Clippy, workspace-test, release-build, and `lithc` smoke gates
- update the Makalu extra-work tracker with completed and remaining work

## Local verification
- targeted `rustfmt --check`: pass
- `cargo check --workspace`: pass
- `cargo clippy -p lithic-syntax -p lithc --all-targets -- -D warnings`: pass
- `git diff --check`: pass

This Windows host has no MSVC linker and Docker is unavailable, so linker-backed tests and release builds must pass in the new three-OS PR workflow before merge.

## Scope boundary
This is still a compiler front-end scaffold. It does not implement full function-body grammar, approved type semantics, typed IR, bytecode/codegen, source maps, LithoVM conformance, deployment, or release publication.