### PR TITLE
fix(toolchain): preserve literals in lithfmt

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -38,8 +38,9 @@ jobs:
           crates/lithic-syntax/src/sema.rs
           crates/lithc/src/main.rs
           crates/lithc/tests/cli.rs
+          crates/lithfmt/src/main.rs
       - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc --all-targets -- -D warnings
+        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -505,7 +505,7 @@ parse/lower full function bodies into deployable LithoVM/EVM bytecode.
 | Tool | Local implementation | Required before full-release acceptance |
 | --- | --- | --- |
 | `lithc` | Lexer/parser, conservative declaration-name checks, and AST/ABI/check output on `main`. | Approved type/overload/map/return semantics, full statements/expressions, typed IR, deterministic bytecode/codegen, source maps, diagnostics, and conformance tests. |
-| `lithfmt` | Parse-safe whitespace normalization and `--check`. | Decide whether v0 is accepted or implement AST-driven canonical formatting/idempotence corpus. |
+| `lithfmt` | Parse-safe whitespace normalization and `--check`; literal-safety fix under review. | Merge literal preservation, then decide whether v0 is accepted or implement AST-driven canonical formatting/idempotence corpus. |
 | `lithlint` | AST-driven L001–L004 rules and warning denial. | Rule/version policy, suppression/config behavior, false-positive corpus, and release documentation. |
 | `lithls` | Stdio LSP lifecycle, full sync, diagnostics, and document symbols. | Editor acceptance; decide whether incremental sync, completion, hover, and go-to-definition are release gates. |
 | `lithdev` | Devnet lifecycle plus check/deploy preparation and ABI output. | Compiler bytecode, simulation, signing, broadcast, receipt verification, and safe network/account configuration. |
@@ -529,12 +529,16 @@ Completed or evidenced locally:
       `lithc` smoke check.
 - [x] PR #95 passed Linux, Windows, and macOS formatting, Clippy, 12 Rust tests, full workspace release builds, and
       `lithc` smoke checks, then merged as `cf68f7c001cd6a847f806cac09659bf72380bda2` (2026-08-16).
+- [x] Reviewed `lithfmt` and found its claimed safe tab/trailing-space normalization also rewrote string and
+      byte-string literal contents; isolated a token-span-based preservation fix and three focused tests.
 
 Remaining actions:
 
 - [x] Merge the reviewed shared syntax/`lithc` and CI slice after its Linux/Windows/macOS gates pass.
 - [ ] Separately review `lithfmt`, `lithlint`, `lithls`, `lithdev`, `lithtest`, `lithsec`, `lithpkg`, release packaging,
       examples, and lockfile.
+- [ ] Merge the `lithfmt` literal-safety fix after three-OS tests and release builds pass; then record whether the
+      whitespace-only v0 formatter is accepted as the release boundary.
 - [ ] Run the full workspace tests/release build on Linux, Windows, and macOS. The 2026-08-03 Windows audit host lacks
       `link.exe`, so it could lint/check but could not link Rust test binaries.
 - [ ] Specify full function-body grammar, semantics, ABI/bytecode compatibility target, and compiler conformance
@@ -630,8 +634,20 @@ Evidence:
 | 2026-08-16 | Lithoswap V2 toolchain audit | PARTIAL | Contract package has no production runtime dependencies; its Hardhat/test-only dependency graph reports 1 critical, 55 high, 43 moderate, and 10 low transitive advisories. |
 | 2026-08-16 | Provider-neutral signer review | MERGED | PR #93 passed all checks and merged as `60f3f7bb`; 11 signer, 18 API, and 88 bridge-contract tests pass; all three production dependency audits report zero. No deployment or key access occurred. |
 | 2026-08-16 | Toolchain shared front-end review | MERGED | PR #95 passed on Linux, Windows, and macOS with 12 Rust tests, full workspace release builds, Clippy/formatting, and `lithc` smoke checks; merged as `cf68f7c0`. |
+| 2026-08-16 | `lithfmt` safety review | PASS, LOCAL | Found literal-content corruption in the whitespace formatter; token-span preservation and three focused regression/idempotence tests pass check/Clippy locally and await three-OS PR CI. |
 
 ## Change log
+
+### 2026-08-16 — MX-07 `lithfmt` safety fix isolated
+
+- Verified the local draft contained no formatter behavior change beyond a release version bump and mechanical
+  formatting; the version bump was not accepted without full-release approval.
+- Found that the tracked formatter expanded tabs inside string/byte-string literals and could trim trailing content
+  inside multiline literals despite describing itself as unable to corrupt a contract.
+- Added lexer-token-span protection so literal bytes remain unchanged while external whitespace is normalized, plus
+  literal, multiline, and idempotence tests.
+- Expanded the three-OS toolchain gate to format and lint `lithfmt`; hosted tests/release builds await PR CI.
+- Updated by: `bachal-mb`.
 
 ### 2026-08-16 — MX-07 shared front-end and CI merged
 

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -13,7 +13,7 @@ the parser is tested against as golden files.
 | Tool       | Status        | What it does today |
 |------------|---------------|--------------------|
 | `lithc`    | **real (front-end)** | Lex + parse `.lithic`, reject unambiguous declaration-name collisions, and support `--emit summary\|ast\|abi\|check`. Full type checking and bytecode codegen are next. |
-| `lithfmt`  | **real (v0)** | Safe whitespace normalisation (tabs→spaces, strip trailing, single trailing newline); refuses to touch files with parse errors. `--check` for CI. |
+| `lithfmt`  | **real (v0)** | Literal-safe whitespace normalisation (tabs→spaces and trailing trim only outside string/byte-string literals, single trailing newline); refuses parse errors. `--check` for CI. |
 | `lithlint` | **real (v0)** | AST-driven lint rules L001–L004 (naming + `@ai_budget` on `pub async fn`). `--deny-warnings` for CI. |
 | `lithls`   | spec-only stub | Language server (LSP). |
 | `lithdev`  | spec-only stub | Local devnet + deploy helper. |

--- a/toolchain/crates/lithfmt/src/main.rs
+++ b/toolchain/crates/lithfmt/src/main.rs
@@ -2,8 +2,8 @@
 //!
 //! v0 performs *safe* whitespace normalisation only — it never rewrites code
 //! structure, so it cannot corrupt a contract:
-//!   * tabs are expanded to four spaces,
-//!   * trailing whitespace is stripped from every line,
+//!   * tabs outside string/byte-string literals are expanded to four spaces,
+//!   * trailing whitespace outside literals is stripped from every line,
 //!   * the file is terminated by exactly one newline.
 //!
 //! The input is parsed first; a file with parse errors is left untouched.
@@ -27,11 +27,47 @@ OPTIONS:\n\
 }
 
 fn format_source(src: &str) -> String {
+    let protected: Vec<(usize, usize)> = lithic_syntax::lexer::lex(src)
+        .into_iter()
+        .filter_map(|token| match token.kind {
+            lithic_syntax::token::TokenKind::Str | lithic_syntax::token::TokenKind::ByteStr => {
+                Some((token.lo, token.hi))
+            }
+            _ => None,
+        })
+        .collect();
+    let is_protected = |position: usize| {
+        let index = protected.partition_point(|(_, hi)| *hi <= position);
+        matches!(protected.get(index), Some((lo, hi)) if position >= *lo && position < *hi)
+    };
+
     let mut out = String::with_capacity(src.len());
-    for line in src.lines() {
-        let expanded = line.replace('\t', "    ");
-        out.push_str(expanded.trim_end());
+    let mut line_start = 0usize;
+    for segment in src.split_inclusive('\n') {
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        let mut content_end = line.len();
+        while content_end > 0 {
+            let character = line[..content_end]
+                .chars()
+                .next_back()
+                .expect("non-empty line prefix");
+            let character_start = content_end - character.len_utf8();
+            if is_protected(line_start + character_start) || !matches!(character, ' ' | '\t' | '\r')
+            {
+                break;
+            }
+            content_end = character_start;
+        }
+
+        for (offset, character) in line[..content_end].char_indices() {
+            if character == '\t' && !is_protected(line_start + offset) {
+                out.push_str("    ");
+            } else {
+                out.push(character);
+            }
+        }
         out.push('\n');
+        line_start += segment.len();
     }
     // Collapse to exactly one trailing newline (handles empty input too).
     while out.ends_with("\n\n") {
@@ -88,7 +124,10 @@ fn main() {
         for d in &res.diagnostics {
             eprintln!("{}", d.render(&src, &path));
         }
-        eprintln!("lithfmt: error: not formatting {} due to parse errors", path);
+        eprintln!(
+            "lithfmt: error: not formatting {} due to parse errors",
+            path
+        );
         exit(1);
     }
 
@@ -108,5 +147,31 @@ fn main() {
             exit(2);
         }
         eprintln!("lithfmt: formatted {}", path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_source;
+
+    #[test]
+    fn normalizes_only_non_literal_whitespace() {
+        let source = "contract C {\n\tconst S: string = \"a\tb  \";   \n\tconst B: bytes = b\"x\ty  \";\t\n}\n\n";
+        let expected = "contract C {\n    const S: string = \"a\tb  \";\n    const B: bytes = b\"x\ty  \";\n}\n";
+        assert_eq!(format_source(source), expected);
+    }
+
+    #[test]
+    fn preserves_multiline_literal_content() {
+        let source = "contract C {\n const S: string = \"first  \n\tsecond\";  \n}\n";
+        let expected = "contract C {\n const S: string = \"first  \n\tsecond\";\n}\n";
+        assert_eq!(format_source(source), expected);
+    }
+
+    #[test]
+    fn formatting_is_idempotent() {
+        let source = "contract C {\n    fn f() {}\n}\n";
+        let once = format_source(source);
+        assert_eq!(format_source(&once), once);
     }
 }


### PR DESCRIPTION
## Summary
- preserve exact string and byte-string literal bytes during lithfmt normalization
- continue expanding tabs and trimming trailing whitespace only outside protected literal token spans
- add literal, multiline-literal, and idempotence regression tests
- extend three-OS formatting/Clippy coverage to lithfmt
- reject the local 0.1.0 bump pending full release approval
- update the MX-07 tracker

## Local verification
- targeted rustfmt: pass
- cargo check --workspace: pass
- reviewed-crate Clippy with -D warnings: pass
- diff check: pass

## Scope
This keeps lithfmt as a whitespace-only v0 formatter. AST-driven canonical formatting and release-boundary acceptance remain open.