### PR TITLE
fix(toolchain): harden lithlint v0 boundaries

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -39,8 +39,10 @@ jobs:
           crates/lithc/src/main.rs
           crates/lithc/tests/cli.rs
           crates/lithfmt/src/main.rs
+          crates/lithlint/src/main.rs
+          crates/lithlint/tests/cli.rs
       - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt --all-targets -- -D warnings
+        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -53,6 +53,21 @@ cargo run -p lithlint -- ../Makalu/contracts/src/FinesseWarriors.lithic
 cargo run -p lithfmt -- --check ../Makalu/contracts/src/DOGE.lithic
 ```
 
+### `lithlint` v0 rule boundary
+
+`lithlint` currently accepts exactly one input file. Findings are warnings unless
+`--deny-warnings` is supplied. The reviewed v0 rule set is deliberately small:
+
+- `L001`: contract names start with an ASCII uppercase letter and contain no underscore.
+- `L002`: function names contain only ASCII lowercase letters, digits, and underscores.
+- `L003`: constant names contain only ASCII uppercase letters, digits, and underscores.
+- `L004`: every `pub async fn` declares an `@ai_budget` attribute.
+
+There is no suppression file, project configuration, or configurable severity in
+v0. L004 checks the declaration boundary only because function bodies are still
+stored as raw source; it does not claim to trace AI calls. Expanding these rules
+or promoting the crate beyond `0.0.1` requires an approved rule/version policy.
+
 ## Roadmap (next phases)
 
 1. `lithc`: specify and implement name resolution + type checking over the declaration AST. The current conservative pass intentionally does not infer unapproved type, overload, map-key, or return rules.

--- a/toolchain/crates/lithlint/src/main.rs
+++ b/toolchain/crates/lithlint/src/main.rs
@@ -5,7 +5,7 @@
 //!   * L002 function names should be snake_case
 //!   * L003 const names should be SCREAMING_SNAKE_CASE
 //!   * L004 `pub async fn` (which can call the AI primitive) should declare an
-//!          `@ai_budget` to bound its cost
+//!     `@ai_budget` to bound its cost
 //!
 //! Findings are warnings by default; pass `--deny-warnings` to exit non-zero.
 
@@ -27,26 +27,41 @@ OPTIONS:\n\
 }
 
 fn is_upper_camel(s: &str) -> bool {
-    !s.is_empty() && s.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false) && !s.contains('_')
+    !s.is_empty()
+        && s.chars()
+            .next()
+            .map(|c| c.is_ascii_uppercase())
+            .unwrap_or(false)
+        && !s.contains('_')
 }
 
 fn is_snake(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
 }
 
 fn is_screaming_snake(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
 fn lint(c: &Contract) -> Vec<String> {
     let mut findings = Vec::new();
 
     if !is_upper_camel(&c.name) {
-        findings.push(format!("L001 contract `{}` should be UpperCamelCase", c.name));
+        findings.push(format!(
+            "L001 contract `{}` should be UpperCamelCase",
+            c.name
+        ));
     }
     for cst in c.consts() {
         if !is_screaming_snake(&cst.name) {
-            findings.push(format!("L003 const `{}` should be SCREAMING_SNAKE_CASE", cst.name));
+            findings.push(format!(
+                "L003 const `{}` should be SCREAMING_SNAKE_CASE",
+                cst.name
+            ));
         }
     }
     for f in c.funcs() {
@@ -77,7 +92,16 @@ fn main() {
                 print_help();
                 return;
             }
-            s if !s.starts_with('-') => path = Some(s.to_string()),
+            s if !s.starts_with('-') => {
+                if let Some(first) = &path {
+                    eprintln!(
+                        "lithlint: error: multiple input files are not supported: '{}' and '{}'",
+                        first, s
+                    );
+                    exit(2);
+                }
+                path = Some(s.to_string());
+            }
             other => {
                 eprintln!("lithlint: error: unknown option '{}'", other);
                 exit(2);
@@ -132,5 +156,71 @@ fn main() {
         if deny {
             exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lint;
+
+    fn lint_source(source: &str) -> Vec<String> {
+        let parsed = lithic_syntax::parse(source);
+        assert_eq!(
+            parsed.error_count(),
+            0,
+            "unexpected diagnostics: {:?}",
+            parsed.diagnostics
+        );
+        lint(&parsed.contract.expect("contract"))
+    }
+
+    #[test]
+    fn clean_contract_has_no_findings() {
+        let source = r#"
+            contract Token {
+                const MAX_SUPPLY: u256 = 1;
+                @ai_budget(max_cost = 1)
+                pub async fn guarded_transfer() {}
+            }
+        "#;
+
+        assert!(lint_source(source).is_empty());
+    }
+
+    #[test]
+    fn naming_rules_report_their_declared_targets() {
+        let source = r#"
+            contract bad_name {
+                const max_supply: u256 = 1;
+                pub fn BadFunction() {}
+            }
+        "#;
+        let findings = lint_source(source);
+
+        assert_eq!(findings.len(), 3);
+        assert!(findings.iter().any(|finding| finding.starts_with("L001 ")));
+        assert!(findings.iter().any(|finding| finding.starts_with("L002 ")));
+        assert!(findings.iter().any(|finding| finding.starts_with("L003 ")));
+    }
+
+    #[test]
+    fn ai_budget_rule_is_limited_to_public_async_functions() {
+        let source = r#"
+            contract Token {
+                pub async fn needs_budget() {}
+                @ai_budget(max_cost = 1)
+                pub async fn has_budget() {}
+                async fn private_async() {}
+                pub fn public_sync() {}
+            }
+        "#;
+        let findings = lint_source(source);
+        let budget_findings: Vec<_> = findings
+            .iter()
+            .filter(|finding| finding.starts_with("L004 "))
+            .collect();
+
+        assert_eq!(budget_findings.len(), 1);
+        assert!(budget_findings[0].contains("needs_budget"));
     }
 }

--- a/toolchain/crates/lithlint/tests/cli.rs
+++ b/toolchain/crates/lithlint/tests/cli.rs
@@ -1,0 +1,55 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn source_file(label: &str, source: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "lithlint-{label}-{}-{nonce}.lithic",
+        std::process::id()
+    ));
+    fs::write(&path, source).expect("write Lithic fixture");
+    path
+}
+
+#[test]
+fn deny_warnings_fails_when_a_finding_is_reported() {
+    let path = source_file("finding", "contract bad_name {}");
+    let output = Command::new(env!("CARGO_BIN_EXE_lithlint"))
+        .arg("--deny-warnings")
+        .arg(&path)
+        .output()
+        .expect("run lithlint");
+    fs::remove_file(&path).expect("remove Lithic fixture");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("L001 contract `bad_name`"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn multiple_input_files_are_rejected_instead_of_silently_ignoring_one() {
+    let first = source_file("first", "contract First {}");
+    let second = source_file("second", "contract Second {}");
+    let output = Command::new(env!("CARGO_BIN_EXE_lithlint"))
+        .arg(&first)
+        .arg(&second)
+        .output()
+        .expect("run lithlint");
+    fs::remove_file(&first).expect("remove first Lithic fixture");
+    fs::remove_file(&second).expect("remove second Lithic fixture");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("multiple input files are not supported"),
+        "stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- keep `lithlint` at `0.0.1` and document the exact L001-L004 v0 boundary
- reject multiple input paths instead of silently linting only the last one
- add three rule-boundary unit tests and two CLI behavior tests
- add `lithlint` sources and all targets to the three-OS rustfmt/Clippy gate

## Verification
- scoped `rustfmt --check`: passed
- `cargo check --workspace`: passed
- scoped Clippy with `-D warnings`: passed
- `git diff --check`: passed
- local test linking is unavailable because this Windows host has no Visual C++ `link.exe`; Linux, Windows, and macOS CI must execute the full workspace tests and release builds before merge

## Boundaries
- no version promotion or release publication
- no new language semantics
- no suppression/configuration policy inferred; those remain product/release-owner decisions