### PR TITLE
docs(toolchain): define honest lithls boundary

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -41,8 +41,10 @@ jobs:
           crates/lithfmt/src/main.rs
           crates/lithlint/src/main.rs
           crates/lithlint/tests/cli.rs
+          crates/lithls/src/main.rs
+          crates/lithls/tests/cli.rs
       - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint --all-targets -- -D warnings
+        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -15,7 +15,7 @@ the parser is tested against as golden files.
 | `lithc`    | **real (front-end)** | Lex + parse `.lithic`, reject unambiguous declaration-name collisions, and support `--emit summary\|ast\|abi\|check`. Full type checking and bytecode codegen are next. |
 | `lithfmt`  | **real (v0)** | Literal-safe whitespace normalisation (tabs→spaces and trailing trim only outside string/byte-string literals, single trailing newline); refuses parse errors. `--check` for CI. |
 | `lithlint` | **real (v0)** | AST-driven lint rules L001–L004 (naming + `@ai_budget` on `pub async fn`). `--deny-warnings` for CI. |
-| `lithls`   | spec-only stub | Language server (LSP). |
+| `lithls`   | **reviewed spec-only** | Explicitly refuses `--stdio`; the protocol, safety, span, test, and acceptance boundary is in [`specs/lithls.md`](specs/lithls.md). |
 | `lithdev`  | spec-only stub | Local devnet + deploy helper. |
 | `lithtest` | spec-only stub | Test runner. |
 | `lithsec`  | spec-only stub | Capability + storage safety scanner. |

--- a/toolchain/crates/lithls/src/main.rs
+++ b/toolchain/crates/lithls/src/main.rs
@@ -1,16 +1,48 @@
-//! `lithls` — Lithic language server. Spec-only stub.
+//! `lithls` — Lithic language-server specification marker.
 
-fn main() {
+use std::process::ExitCode;
+
+const STATUS: &str = "lithls is specification-only in this scaffold; no LSP server is available";
+
+fn print_help() {
     println!(
-        "lithls {} — Lithic language server (SPEC-ONLY, not yet implemented)\n\
+        "lithls {} — Lithic language server (specification-only)\n\
 \n\
-Planned responsibilities:\n\
-  * LSP server over stdio for editors (VS Code, Neovim, JetBrains)\n\
-  * diagnostics on save (reuse lithic-syntax + lithlint)\n\
-  * go-to-definition, hover types, completion for contract members\n\
-  * document symbols / outline from the declaration AST\n\
+USAGE:\n\
+    lithls [--help | --version | --stdio]\n\
 \n\
-This binary currently exits without serving. See toolchain/README.md.",
+OPTIONS:\n\
+    --stdio    Fail explicitly because the LSP server is not implemented\n\
+    --version  Print the package version\n\
+    -h, --help Print this help\n\
+\n\
+See toolchain/specs/lithls.md for the reviewed implementation boundary.",
         env!("CARGO_PKG_VERSION")
     );
+}
+
+fn main() -> ExitCode {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    match args.as_slice() {
+        [] => {
+            println!("{STATUS}");
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "-h" || arg == "--help" => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--version" => {
+            println!("lithls {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--stdio" => {
+            eprintln!("lithls: unavailable: {STATUS}");
+            ExitCode::from(3)
+        }
+        _ => {
+            eprintln!("lithls: error: unsupported arguments");
+            ExitCode::from(2)
+        }
+    }
 }

--- a/toolchain/crates/lithls/tests/cli.rs
+++ b/toolchain/crates/lithls/tests/cli.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+#[test]
+fn reports_the_package_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithls"))
+        .arg("--version")
+        .output()
+        .expect("run lithls");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "lithls 0.0.1\n");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn stdio_mode_fails_explicitly_instead_of_claiming_lsp_support() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithls"))
+        .arg("--stdio")
+        .output()
+        .expect("run lithls");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("specification-only"), "stderr: {stderr}");
+}
+
+#[test]
+fn unsupported_arguments_are_rejected() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithls"))
+        .arg("--serve")
+        .output()
+        .expect("run lithls");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unsupported arguments"));
+}

--- a/toolchain/specs/lithls.md
+++ b/toolchain/specs/lithls.md
@@ -1,0 +1,70 @@
+# `lithls` implementation specification
+
+Status: reviewed specification only. The `lithls` crate remains at `0.0.1` and
+must not advertise or start an LSP server. This boundary follows the original
+toolchain target, which lists `lithls` as specification-only in this scaffold.
+
+Normative references verified on 2026-08-16:
+
+- Language Server Protocol 3.17 specification:
+  <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/>
+- JSON-RPC 2.0 specification: <https://www.jsonrpc.org/specification>
+
+## Minimum implementation boundary
+
+A future implementation may be called an LSP server only when all requirements
+in this section are implemented and tested together.
+
+1. **Transport:** stdio framing uses ASCII headers, a required `Content-Length`
+   measured in content bytes, the header/content separator required by LSP, and
+   UTF-8 JSON content. Truncated, oversized, duplicate, malformed, or unsupported
+   headers fail deterministically without panicking or allocating unbounded input.
+2. **JSON-RPC 2.0:** use a conforming JSON parser. Preserve string, number, and
+   `null` request IDs exactly; never reply to notifications; distinguish parse
+   error, invalid request, invalid params, method-not-found, and internal error;
+   and emit exactly one of `result` or `error` in a response.
+3. **Lifecycle:** enforce `initialize` before normal requests, accept
+   `initialized`, implement `shutdown`, and honor `exit` with the protocol-defined
+   success/failure behavior. Capabilities must describe only implemented features.
+4. **Document synchronization:** implement `didOpen`, `didChange`, and `didClose`
+   as one coherent capability. Version updates must be ordered and stale changes
+   rejected. The initial implementation uses full-document synchronization unless
+   incremental synchronization is separately implemented and accepted.
+5. **Positions:** negotiate an LSP 3.17 position encoding or correctly use the
+   protocol fallback. Parser byte offsets must be converted to the negotiated
+   character units, including non-ASCII and non-BMP text and all supported line
+   endings.
+6. **Diagnostics:** publish syntax and conservative declaration diagnostics for
+   the synchronized document version. Every diagnostic needs a real source span;
+   closing a document clears its diagnostics.
+7. **Document symbols:** return only symbols backed by declaration spans in the
+   parser AST. Placeholder ranges such as `0:0..0:1` are forbidden.
+
+Completion, hover, go-to-definition, incremental synchronization, workspace
+features, and lint configuration are not part of this minimum boundary. They
+must not be advertised until their semantics and release priority are approved.
+
+## Required verification
+
+- Framing tests for byte lengths, partial reads, multiple sequential messages,
+  UTF-8 content, malformed headers, bounded message size, and clean EOF.
+- JSON-RPC conformance tests covering every accepted ID type, notifications,
+  malformed JSON, invalid requests/params, unknown methods, and escaping.
+- Lifecycle state-machine tests, including requests before initialization,
+  repeated initialize/shutdown, and both exit paths.
+- Synchronization tests for open/change/close, monotonically increasing versions,
+  multiple documents, and diagnostic clearing.
+- Position/range fixtures containing ASCII, multibyte UTF-8, non-BMP characters,
+  LF, CRLF, and CR line endings.
+- Real-span diagnostic and document-symbol fixtures against both tracked Makalu
+  contracts.
+- End-to-end stdio sessions from at least two approved editor clients on Linux,
+  Windows, and macOS, followed by editor-owner and release-owner acceptance.
+
+## Rejected draft boundary
+
+The local uncommitted draft reviewed on 2026-08-16 is not an acceptable basis for
+release. It promotes the package to `0.1.0`, extracts JSON fields with substring
+search, ignores required JSON-RPC validation/error behavior, emits placeholder
+symbol and semantic ranges, does not implement position encoding, and has no
+editor conformance evidence. None of that draft is included in this slice.


### PR DESCRIPTION
## Summary
- keep `lithls` at `0.0.1` and specification-only, matching the original scaffold target
- explicitly reject `--stdio` so the stub cannot be mistaken for a working language server
- add a reviewed LSP 3.17 / JSON-RPC 2.0 implementation and conformance boundary
- add three CLI tests and extend the three-OS formatting/Clippy gate to `lithls`

## Verification
- scoped `rustfmt --check`: passed
- `cargo check --workspace`: passed
- scoped Clippy with `-D warnings`: passed
- `git diff --check`: passed
- full test execution/release linking is delegated to the required Linux, Windows, and macOS CI jobs because this local Windows host lacks `link.exe`

## Excluded draft
The uncommitted local `0.1.0` draft is not included: its substring-based JSON extraction, placeholder ranges, missing position encoding/lifecycle conformance, and absent editor evidence do not satisfy the reviewed protocol boundary.

No language-server implementation or release is claimed.