### PR TITLE
feat(toolchain): add safe lithdev v0 boundary

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -43,8 +43,10 @@ jobs:
           crates/lithlint/tests/cli.rs
           crates/lithls/src/main.rs
           crates/lithls/tests/cli.rs
+          crates/lithdev/src/main.rs
+          crates/lithdev/tests/cli.rs
       - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls --all-targets -- -D warnings
+        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls -p lithdev --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -16,7 +16,7 @@ the parser is tested against as golden files.
 | `lithfmt`  | **real (v0)** | Literal-safe whitespace normalisation (tabs→spaces and trailing trim only outside string/byte-string literals, single trailing newline); refuses parse errors. `--check` for CI. |
 | `lithlint` | **real (v0)** | AST-driven lint rules L001–L004 (naming + `@ai_budget` on `pub async fn`). `--deny-warnings` for CI. |
 | `lithls`   | **reviewed spec-only** | Explicitly refuses `--stdio`; the protocol, safety, span, test, and acceptance boundary is in [`specs/lithls.md`](specs/lithls.md). |
-| `lithdev`  | spec-only stub | Local devnet + deploy helper. |
+| `lithdev`  | **real (bounded v0)** | Strict local Compose lifecycle, declaration checks, read-only ABI output, and fail-closed deploy preflight. Volume deletion, signing, broadcast, and receipt claims are excluded. |
 | `lithtest` | spec-only stub | Test runner. |
 | `lithsec`  | spec-only stub | Capability + storage safety scanner. |
 | `lithpkg`  | spec-only stub | Package manager. |
@@ -51,6 +51,8 @@ cargo run -p lithc -- ../Makalu/contracts/src/DOGE.lithic
 cargo run -p lithc -- --emit abi ../Makalu/contracts/src/DOGE.lithic
 cargo run -p lithlint -- ../Makalu/contracts/src/FinesseWarriors.lithic
 cargo run -p lithfmt -- --check ../Makalu/contracts/src/DOGE.lithic
+cargo run -p lithdev -- status
+cargo run -p lithdev -- check ../Makalu/contracts/src/DOGE.lithic
 ```
 
 ### `lithlint` v0 rule boundary

--- a/toolchain/crates/lithdev/Cargo.toml
+++ b/toolchain/crates/lithdev/Cargo.toml
@@ -3,8 +3,11 @@ name = "lithdev"
 version = "0.0.1"
 edition = "2021"
 license = "Apache-2.0"
-description = "lithdev — local devnet and deployment helper (spec-only stub)."
+description = "lithdev — safe local-devnet lifecycle and deployment preflight."
 
 [[bin]]
 name = "lithdev"
 path = "src/main.rs"
+
+[dependencies]
+lithic-syntax = { path = "../lithic-syntax" }

--- a/toolchain/crates/lithdev/src/main.rs
+++ b/toolchain/crates/lithdev/src/main.rs
@@ -1,17 +1,385 @@
-//! `lithdev` — local devnet and deployment helper. Spec-only stub.
+//! `lithdev` — safe local-devnet lifecycle and deployment preflight.
 
-fn main() {
+use lithic_syntax::Contract;
+use std::path::{Path, PathBuf};
+use std::process::{Command as ProcessCommand, ExitCode};
+
+const COMPOSE_RELATIVE_PATH: &str = "Makalu/docker-compose.dev.yml";
+
+#[derive(Debug, PartialEq, Eq)]
+enum Command {
+    Up {
+        file: Option<PathBuf>,
+        build: bool,
+    },
+    Down {
+        file: Option<PathBuf>,
+    },
+    Status {
+        file: Option<PathBuf>,
+    },
+    Logs {
+        file: Option<PathBuf>,
+        follow: bool,
+        service: Option<String>,
+    },
+    Check {
+        source: PathBuf,
+    },
+    Abi {
+        source: PathBuf,
+    },
+    Deploy {
+        source: PathBuf,
+    },
+    Help,
+    Version,
+}
+
+fn print_help() {
     println!(
-        "lithdev {} — local devnet & deployment helper (SPEC-ONLY, not yet implemented)\n\
+        "lithdev {} — safe local-devnet lifecycle and deployment preflight\n\
 \n\
-Planned responsibilities:\n\
-  * `lithdev up` — start a local LithoVM devnet (wraps the existing\n\
-    docker-compose.dev.yml / anvil stack)\n\
-  * `lithdev deploy <FILE.lithic>` — compile via lithc and deploy to a target\n\
-    RPC (defaults to the local devnet, or rpc.litho.ai for Makalu)\n\
-  * `lithdev call/send` — interact with a deployed contract using its ABI\n\
+USAGE:\n\
+    lithdev <COMMAND> [OPTIONS]\n\
 \n\
-This binary currently exits without acting. See toolchain/README.md.",
+COMMANDS:\n\
+    up [--build] [--file PATH]       Start the local stack in the background\n\
+    down [--file PATH]               Stop the stack and preserve all volumes\n\
+    status [--file PATH]             Show stack services and ports\n\
+    logs [SERVICE] [--follow] [--file PATH]\n\
+                                     Show stack logs\n\
+    check <FILE.lithic>              Run parser and declaration checks\n\
+    abi <FILE.lithic>                Print declaration-derived ABI to stdout\n\
+    deploy <FILE.lithic>             Validate, then fail closed before broadcast\n\
+\n\
+`deploy` cannot broadcast until `lithc` emits approved deployable bytecode.\n\
+Volume deletion, signing, RPC submission, and receipt verification are not\n\
+implemented in this v0 boundary.",
         env!("CARGO_PKG_VERSION")
     );
+}
+
+fn parse_compose_options(
+    args: &[String],
+    allow_build: bool,
+    allow_logs: bool,
+) -> Result<(Option<PathBuf>, bool, bool, Option<String>), String> {
+    let mut file = None;
+    let mut build = false;
+    let mut follow = false;
+    let mut service = None;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--file" => {
+                if file.is_some() {
+                    return Err("--file may be supplied only once".into());
+                }
+                index += 1;
+                let value = args.get(index).ok_or("--file requires a path")?;
+                file = Some(PathBuf::from(value));
+            }
+            "--build" if allow_build => {
+                if build {
+                    return Err("--build may be supplied only once".into());
+                }
+                build = true;
+            }
+            "--follow" | "-f" if allow_logs => {
+                if follow {
+                    return Err("--follow may be supplied only once".into());
+                }
+                follow = true;
+            }
+            value if allow_logs && !value.starts_with('-') => {
+                if service.is_some() {
+                    return Err("logs accepts at most one service name".into());
+                }
+                service = Some(value.to_string());
+            }
+            value => return Err(format!("unsupported option or argument `{value}`")),
+        }
+        index += 1;
+    }
+
+    Ok((file, build, follow, service))
+}
+
+fn one_source(command: &str, args: &[String]) -> Result<PathBuf, String> {
+    match args {
+        [source] => Ok(PathBuf::from(source)),
+        [] => Err(format!("{command} requires exactly one <FILE.lithic>")),
+        _ => Err(format!("{command} accepts exactly one <FILE.lithic>")),
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<Command, String> {
+    let (name, rest) = args.split_first().ok_or("no command supplied")?;
+    match name.as_str() {
+        "-h" | "--help" => {
+            if rest.is_empty() {
+                Ok(Command::Help)
+            } else {
+                Err("--help does not accept arguments".into())
+            }
+        }
+        "--version" => {
+            if rest.is_empty() {
+                Ok(Command::Version)
+            } else {
+                Err("--version does not accept arguments".into())
+            }
+        }
+        "up" => {
+            let (file, build, _, _) = parse_compose_options(rest, true, false)?;
+            Ok(Command::Up { file, build })
+        }
+        "down" => {
+            let (file, _, _, _) = parse_compose_options(rest, false, false)?;
+            Ok(Command::Down { file })
+        }
+        "status" => {
+            let (file, _, _, _) = parse_compose_options(rest, false, false)?;
+            Ok(Command::Status { file })
+        }
+        "logs" => {
+            let (file, _, follow, service) = parse_compose_options(rest, false, true)?;
+            Ok(Command::Logs {
+                file,
+                follow,
+                service,
+            })
+        }
+        "check" => Ok(Command::Check {
+            source: one_source("check", rest)?,
+        }),
+        "abi" => Ok(Command::Abi {
+            source: one_source("abi", rest)?,
+        }),
+        "deploy" => Ok(Command::Deploy {
+            source: one_source("deploy", rest)?,
+        }),
+        other => Err(format!("unknown command `{other}`")),
+    }
+}
+
+fn find_compose_file() -> Result<PathBuf, String> {
+    let mut directory = std::env::current_dir().map_err(|error| error.to_string())?;
+    loop {
+        let repo_candidate = directory.join(COMPOSE_RELATIVE_PATH);
+        if repo_candidate.is_file() {
+            return Ok(repo_candidate);
+        }
+        let makalu_candidate = directory.join("docker-compose.dev.yml");
+        if directory.file_name().and_then(|name| name.to_str()) == Some("Makalu")
+            && makalu_candidate.is_file()
+        {
+            return Ok(makalu_candidate);
+        }
+        if !directory.pop() {
+            return Err(format!(
+                "could not find {COMPOSE_RELATIVE_PATH}; run inside the repository or pass --file PATH"
+            ));
+        }
+    }
+}
+
+fn resolve_compose_file(explicit: Option<PathBuf>) -> Result<PathBuf, String> {
+    let path = match explicit {
+        Some(path) => path,
+        None => find_compose_file()?,
+    };
+    if !path.is_file() {
+        return Err(format!("compose file does not exist: {}", path.display()));
+    }
+    std::fs::canonicalize(&path)
+        .map_err(|error| format!("cannot resolve compose file {}: {error}", path.display()))
+}
+
+fn run_compose(file: &Path, args: &[&str]) -> Result<ExitCode, String> {
+    let status = ProcessCommand::new("docker")
+        .arg("compose")
+        .arg("--file")
+        .arg(file)
+        .args(args)
+        .status()
+        .map_err(|error| format!("cannot run `docker compose`: {error}"))?;
+    let code = status.code().unwrap_or(1);
+    Ok(ExitCode::from(u8::try_from(code).unwrap_or(1)))
+}
+
+fn checked_contract(path: &Path) -> Result<Contract, u8> {
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) => {
+            eprintln!("lithdev: error: cannot read {}: {error}", path.display());
+            return Err(2);
+        }
+    };
+    let parsed = lithic_syntax::parse(&source);
+    for diagnostic in &parsed.diagnostics {
+        eprintln!(
+            "{}",
+            diagnostic.render(&source, path.to_string_lossy().as_ref())
+        );
+    }
+    if parsed.error_count() > 0 {
+        eprintln!(
+            "lithdev: error: cannot inspect {} due to parse errors",
+            path.display()
+        );
+        return Err(1);
+    }
+    let contract = match parsed.contract {
+        Some(contract) => contract,
+        None => {
+            eprintln!("lithdev: error: no contract found in {}", path.display());
+            return Err(1);
+        }
+    };
+    let findings = lithic_syntax::check(&contract);
+    for finding in &findings {
+        eprintln!("{}", finding.render(path.to_string_lossy().as_ref()));
+    }
+    if lithic_syntax::sema::error_count(&findings) > 0 {
+        eprintln!(
+            "lithdev: error: declaration checks failed for {}",
+            path.display()
+        );
+        return Err(1);
+    }
+    Ok(contract)
+}
+
+fn execute(command: Command) -> Result<ExitCode, String> {
+    match command {
+        Command::Help => {
+            print_help();
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::Version => {
+            println!("lithdev {}", env!("CARGO_PKG_VERSION"));
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::Up { file, build } => {
+            let file = resolve_compose_file(file)?;
+            let mut args = vec!["up", "--detach", "--remove-orphans"];
+            if build {
+                args.push("--build");
+            }
+            run_compose(&file, &args)
+        }
+        Command::Down { file } => {
+            let file = resolve_compose_file(file)?;
+            run_compose(&file, &["down", "--remove-orphans", "--timeout", "15"])
+        }
+        Command::Status { file } => {
+            let file = resolve_compose_file(file)?;
+            run_compose(&file, &["ps"])
+        }
+        Command::Logs {
+            file,
+            follow,
+            service,
+        } => {
+            let file = resolve_compose_file(file)?;
+            let mut args = vec!["logs", "--tail", "200"];
+            if follow {
+                args.push("--follow");
+            }
+            if let Some(service) = service.as_deref() {
+                args.push(service);
+            }
+            run_compose(&file, &args)
+        }
+        Command::Check { source } => match checked_contract(&source) {
+            Ok(_) => {
+                eprintln!("{}: declaration checks clean", source.display());
+                Ok(ExitCode::SUCCESS)
+            }
+            Err(code) => Ok(ExitCode::from(code)),
+        },
+        Command::Abi { source } => match checked_contract(&source) {
+            Ok(contract) => {
+                println!("{}", contract.to_abi_json());
+                Ok(ExitCode::SUCCESS)
+            }
+            Err(code) => Ok(ExitCode::from(code)),
+        },
+        Command::Deploy { source } => match checked_contract(&source) {
+            Ok(contract) => {
+                eprintln!(
+                    "lithdev: unavailable: `{}` passed declaration checks, but lithc emits no approved deployable bytecode; no file was written and no RPC request was sent",
+                    contract.name
+                );
+                Ok(ExitCode::from(3))
+            }
+            Err(code) => Ok(ExitCode::from(code)),
+        },
+    }
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let command = match parse_args(&args) {
+        Ok(command) => command,
+        Err(error) => {
+            eprintln!("lithdev: error: {error}");
+            return ExitCode::from(2);
+        }
+    };
+    match execute(command) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("lithdev: error: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_args, Command};
+    use std::path::PathBuf;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_non_destructive_down() {
+        assert_eq!(
+            parse_args(&args(&["down", "--file", "stack.yml"])),
+            Ok(Command::Down {
+                file: Some(PathBuf::from("stack.yml"))
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_volume_deletion_flag() {
+        let error = parse_args(&args(&["down", "--volumes"])).expect_err("must reject");
+        assert!(error.contains("unsupported option"));
+    }
+
+    #[test]
+    fn rejects_extra_contract_paths() {
+        let error =
+            parse_args(&args(&["deploy", "one.lithic", "two.lithic"])).expect_err("must reject");
+        assert!(error.contains("exactly one"));
+    }
+
+    #[test]
+    fn parses_one_log_service_and_follow_mode() {
+        assert_eq!(
+            parse_args(&args(&["logs", "api", "--follow"])),
+            Ok(Command::Logs {
+                file: None,
+                follow: true,
+                service: Some("api".into())
+            })
+        );
+    }
 }

--- a/toolchain/crates/lithdev/tests/cli.rs
+++ b/toolchain/crates/lithdev/tests/cli.rs
@@ -1,0 +1,88 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn source_file(label: &str, source: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "lithdev-{label}-{}-{nonce}.lithic",
+        std::process::id()
+    ));
+    fs::write(&path, source).expect("write Lithic fixture");
+    path
+}
+
+#[test]
+fn check_reports_conservative_declaration_checks() {
+    let source = source_file("check", "contract Token { state { value: u256; } }");
+    let output = Command::new(env!("CARGO_BIN_EXE_lithdev"))
+        .arg("check")
+        .arg(&source)
+        .output()
+        .expect("run lithdev");
+    fs::remove_file(&source).expect("remove Lithic fixture");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("declaration checks clean"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("type-check"), "stderr: {stderr}");
+}
+
+#[test]
+fn abi_writes_only_to_stdout() {
+    let source = source_file("abi", "contract Token { pub fn balance() -> u256 {} }");
+    let output_path = source.with_extension("abi.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_lithdev"))
+        .arg("abi")
+        .arg(&source)
+        .output()
+        .expect("run lithdev");
+    fs::remove_file(&source).expect("remove Lithic fixture");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("balance"));
+    assert!(!output_path.exists(), "ABI command must not create a file");
+}
+
+#[test]
+fn deploy_fails_closed_without_writing_or_contacting_rpc() {
+    let source = source_file("deploy", "contract Token {}");
+    let output_path = source.with_extension("abi.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_lithdev"))
+        .arg("deploy")
+        .arg(&source)
+        .output()
+        .expect("run lithdev");
+    fs::remove_file(&source).expect("remove Lithic fixture");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no file was written"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("no RPC request was sent"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !output_path.exists(),
+        "deploy preflight must not create ABI"
+    );
+}
+
+#[test]
+fn volume_deletion_is_rejected_before_docker_is_invoked() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithdev"))
+        .args(["down", "--volumes"])
+        .output()
+        .expect("run lithdev");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unsupported option"));
+}


### PR DESCRIPTION
## Summary
- implement strict local Compose `up`, non-destructive `down`, `status`, and `logs` commands
- expose conservative declaration checks and read-only ABI output without calling them full type checking
- make `deploy` fail closed before file writes, signing, RPC submission, or receipt claims
- reject destructive `down --volumes`, irrelevant options, duplicate options, and extra contract paths
- add four parser/safety unit tests plus four CLI tests and extend the three-OS gate

## Verification
- scoped `rustfmt --check`: passed
- `cargo check --workspace`: passed
- scoped Clippy with `-D warnings`: passed
- `git diff --check`: passed
- full tests and release linking require the Linux, Windows, and macOS hosted jobs because this Windows host lacks `link.exe`

## Safety boundary
No volume deletion, key access, signing, deployment, RPC mutation, or artifact overwrite is implemented. Docker was not invoked on this host. `lithdev deploy` exits 3 after validation and states that no file or RPC action occurred.

The package remains `0.0.1`; no release is published.