### PR TITLE
docs(toolchain): define honest lithtest boundary

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -45,8 +45,10 @@ jobs:
           crates/lithls/tests/cli.rs
           crates/lithdev/src/main.rs
           crates/lithdev/tests/cli.rs
+          crates/lithtest/src/main.rs
+          crates/lithtest/tests/cli.rs
       - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls -p lithdev --all-targets -- -D warnings
+        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls -p lithdev -p lithtest --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -17,7 +17,7 @@ the parser is tested against as golden files.
 | `lithlint` | **real (v0)** | AST-driven lint rules L001–L004 (naming + `@ai_budget` on `pub async fn`). `--deny-warnings` for CI. |
 | `lithls`   | **reviewed spec-only** | Explicitly refuses `--stdio`; the protocol, safety, span, test, and acceptance boundary is in [`specs/lithls.md`](specs/lithls.md). |
 | `lithdev`  | **real (bounded v0)** | Strict local Compose lifecycle, declaration checks, read-only ABI output, and fail-closed deploy preflight. Volume deletion, signing, broadcast, and receipt claims are excluded. |
-| `lithtest` | spec-only stub | Test runner. |
+| `lithtest` | **reviewed spec-only** | Explicitly refuses `--run`; the syntax-owner, compiler/VM, isolation, failure, conformance, and acceptance boundary is in [`specs/lithtest.md`](specs/lithtest.md). |
 | `lithsec`  | spec-only stub | Capability + storage safety scanner. |
 | `lithpkg`  | spec-only stub | Package manager. |
 

--- a/toolchain/crates/lithtest/src/main.rs
+++ b/toolchain/crates/lithtest/src/main.rs
@@ -1,15 +1,49 @@
-//! `lithtest` — Lithic test runner. Spec-only stub.
+//! `lithtest` — Lithic test-runner specification marker.
 
-fn main() {
+use std::process::ExitCode;
+
+const STATUS: &str =
+    "lithtest is specification-only in this scaffold; no Lithic tests are executed";
+
+fn print_help() {
     println!(
-        "lithtest {} — Lithic test runner (SPEC-ONLY, not yet implemented)\n\
+        "lithtest {} — Lithic test runner (specification-only)\n\
 \n\
-Planned responsibilities:\n\
-  * discover and run `#[test]`-style functions in .lithic test modules\n\
-  * execute against an in-process LithoVM with cheatcodes (warp, prank, expect)\n\
-  * report pass/fail with gas usage and coverage\n\
+USAGE:\n\
+    lithtest [--help | --version | --run]\n\
 \n\
-This binary currently exits without running tests. See toolchain/README.md.",
+OPTIONS:\n\
+    --run      Fail explicitly because VM-backed test execution is unavailable\n\
+    --version  Print the package version\n\
+    -h, --help Print this help\n\
+\n\
+See toolchain/specs/lithtest.md for the reviewed implementation boundary.",
         env!("CARGO_PKG_VERSION")
     );
+}
+
+fn main() -> ExitCode {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    match args.as_slice() {
+        [] => {
+            println!("{STATUS}");
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "-h" || arg == "--help" => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--version" => {
+            println!("lithtest {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--run" => {
+            eprintln!("lithtest: unavailable: {STATUS}");
+            ExitCode::from(3)
+        }
+        _ => {
+            eprintln!("lithtest: error: unsupported arguments");
+            ExitCode::from(2)
+        }
+    }
 }

--- a/toolchain/crates/lithtest/tests/cli.rs
+++ b/toolchain/crates/lithtest/tests/cli.rs
@@ -1,0 +1,40 @@
+use std::process::Command;
+
+#[test]
+fn reports_the_package_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithtest"))
+        .arg("--version")
+        .output()
+        .expect("run lithtest");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "lithtest 0.0.1\n");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn run_mode_fails_instead_of_reporting_fake_test_results() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithtest"))
+        .arg("--run")
+        .output()
+        .expect("run lithtest");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no Lithic tests are executed"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn source_paths_are_rejected_until_test_syntax_is_approved() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithtest"))
+        .arg("sample.lithic")
+        .output()
+        .expect("run lithtest");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unsupported arguments"));
+}

--- a/toolchain/specs/lithtest.md
+++ b/toolchain/specs/lithtest.md
@@ -1,0 +1,62 @@
+# `lithtest` implementation specification
+
+Status: reviewed specification only. The `lithtest` crate remains at `0.0.1`
+and must not discover, execute, or report Lithic tests as passing. This matches
+the original toolchain target, which lists the test runner as specification-only
+in this scaffold.
+
+## Required owner inputs
+
+Implementation is blocked until the Lithic/compiler and LithoVM owners approve:
+
+- test module/file discovery rules and the exact test annotation syntax;
+- setup, teardown, fixtures, parameterization, and expected-failure semantics;
+- assertion and failure/revert behavior;
+- account, caller, value, time, block, storage, and chain-state isolation rules;
+- supported cheatcodes and their security boundary;
+- gas accounting and whether coverage is a v0 release gate;
+- the compiler/VM conformance vectors that the runner must execute.
+
+No syntax or runtime behavior in this list may be inferred from raw function-body
+text or from another smart-contract language.
+
+## Minimum implementation boundary
+
+A future implementation may be called a test runner only when it:
+
+1. compiles the approved test language through the same typed compiler and
+   deterministic bytecode path used for deployable contracts;
+2. executes each test in an approved LithoVM implementation, with deterministic
+   state isolation and explicit environment configuration;
+3. treats unsupported syntax, compilation failures, VM errors, unexpected
+   reverts, timeouts, and tests with no executable body as failures rather than
+   passes;
+4. reports source-backed failure locations and preserves the underlying compiler
+   and VM diagnostics;
+5. uses stable exit codes for success, test failure, invalid input/configuration,
+   and unavailable infrastructure;
+6. never accesses production RPC endpoints, production keys, or shared state;
+7. labels gas and coverage data only when the approved VM instrumentation
+   produces those values.
+
+## Required verification
+
+- Discovery fixtures for included, excluded, duplicate, malformed, and empty
+  tests after the syntax is approved.
+- Compiler failure, expected/unexpected revert, assertion, timeout, panic, and VM
+  infrastructure cases with exact exit-code assertions.
+- Per-test and per-file isolation fixtures for storage, balances, caller, value,
+  block/time, events, and deployed contracts.
+- Deterministic repeated and parallel runs with stable ordering and output.
+- Source-location tests including non-ASCII text and generated code/source maps.
+- Approved compiler/LithoVM conformance vectors on Linux, Windows, and macOS.
+- Release-owner acceptance of output format, gas reporting, coverage scope, and
+  supported editor/CI integrations.
+
+## Rejected draft boundary
+
+The local uncommitted draft reviewed on 2026-08-16 is not acceptable for release.
+It promotes the crate to `0.1.0` and scans raw body strings for assertion-like
+text. It can match comments or literals, ignores arbitrary non-assertion code,
+passes tests with no assertions, evaluates no contract state or control flow,
+and executes no LithoVM bytecode. None of that draft is included in this slice.


### PR DESCRIPTION
## Summary
- keep `lithtest` at `0.0.1` and specification-only, matching the original scaffold target
- explicitly reject `--run` and source paths so raw body text cannot be reported as executed tests
- document the required syntax-owner, compiler/VM, isolation, failure, conformance, gas, and coverage gates
- add three fail-closed CLI tests and extend the three-OS formatting/Clippy gate

## Verification
- scoped `rustfmt --check`: passed
- `cargo check --workspace`: passed
- scoped Clippy with `-D warnings`: passed
- `git diff --check`: passed
- full tests/release linking require hosted Linux, Windows, and macOS jobs because this Windows host lacks `link.exe`

## Excluded draft
The uncommitted `0.1.0` raw-body assertion scanner is excluded: it can match comments/strings, ignores arbitrary code, passes zero-assertion tests, and executes no LithoVM state or bytecode.

No test-runner implementation or release is claimed.