### PR TITLE
docs(toolchain): define honest lithsec boundary

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -47,8 +47,10 @@ jobs:
           crates/lithdev/tests/cli.rs
           crates/lithtest/src/main.rs
           crates/lithtest/tests/cli.rs
+          crates/lithsec/src/main.rs
+          crates/lithsec/tests/cli.rs
       - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls -p lithdev -p lithtest --all-targets -- -D warnings
+        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls -p lithdev -p lithtest -p lithsec --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -18,7 +18,7 @@ the parser is tested against as golden files.
 | `lithls`   | **reviewed spec-only** | Explicitly refuses `--stdio`; the protocol, safety, span, test, and acceptance boundary is in [`specs/lithls.md`](specs/lithls.md). |
 | `lithdev`  | **real (bounded v0)** | Strict local Compose lifecycle, declaration checks, read-only ABI output, and fail-closed deploy preflight. Volume deletion, signing, broadcast, and receipt claims are excluded. |
 | `lithtest` | **reviewed spec-only** | Explicitly refuses `--run`; the syntax-owner, compiler/VM, isolation, failure, conformance, and acceptance boundary is in [`specs/lithtest.md`](specs/lithtest.md). |
-| `lithsec`  | spec-only stub | Capability + storage safety scanner. |
+| `lithsec`  | **reviewed spec-only** | Explicitly refuses `--scan`; the threat-model, typed-analysis, rule, corpus, false-result, conformance, and acceptance boundary is in [`specs/lithsec.md`](specs/lithsec.md). |
 | `lithpkg`  | spec-only stub | Package manager. |
 
 The shared crate `lithic-syntax` holds the lexer, parser, AST and diagnostics;

--- a/toolchain/crates/lithsec/src/main.rs
+++ b/toolchain/crates/lithsec/src/main.rs
@@ -1,17 +1,49 @@
-//! `lithsec` — capability and storage safety scanner. Spec-only stub.
+//! `lithsec` — Lithic security-scanner specification marker.
 
-fn main() {
+use std::process::ExitCode;
+
+const STATUS: &str =
+    "lithsec is specification-only in this scaffold; no security scan is performed";
+
+fn print_help() {
     println!(
-        "lithsec {} — capability & storage safety scanner (SPEC-ONLY, not yet implemented)\n\
+        "lithsec {} — capability and storage safety scanner (specification-only)\n\
 \n\
-Planned responsibilities:\n\
-  * capability analysis: which functions can mint/burn/pause, and who holds the\n\
-    roles that gate them\n\
-  * storage safety: detect unbounded growth, missing access checks on state\n\
-    mutation, and reentrancy-prone external calls\n\
-  * AI-primitive review: flag `await ai.request` paths without an @ai_budget\n\
+USAGE:\n\
+    lithsec [--help | --version | --scan]\n\
 \n\
-This binary currently exits without scanning. See toolchain/README.md.",
+OPTIONS:\n\
+    --scan     Fail explicitly because the reviewed scanner is unavailable\n\
+    --version  Print the package version\n\
+    -h, --help Print this help\n\
+\n\
+See toolchain/specs/lithsec.md for the reviewed implementation boundary.",
         env!("CARGO_PKG_VERSION")
     );
+}
+
+fn main() -> ExitCode {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    match args.as_slice() {
+        [] => {
+            println!("{STATUS}");
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "-h" || arg == "--help" => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--version" => {
+            println!("lithsec {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--scan" => {
+            eprintln!("lithsec: unavailable: {STATUS}");
+            ExitCode::from(3)
+        }
+        _ => {
+            eprintln!("lithsec: error: unsupported arguments");
+            ExitCode::from(2)
+        }
+    }
 }

--- a/toolchain/crates/lithsec/tests/cli.rs
+++ b/toolchain/crates/lithsec/tests/cli.rs
@@ -1,0 +1,40 @@
+use std::process::Command;
+
+#[test]
+fn reports_the_package_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithsec"))
+        .arg("--version")
+        .output()
+        .expect("run lithsec");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "lithsec 0.0.1\n");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn scan_mode_fails_instead_of_reporting_unreviewed_security_results() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithsec"))
+        .arg("--scan")
+        .output()
+        .expect("run lithsec");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no security scan is performed"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn source_paths_are_rejected_until_rules_are_approved() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithsec"))
+        .arg("contract.lithic")
+        .output()
+        .expect("run lithsec");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unsupported arguments"));
+}

--- a/toolchain/specs/lithsec.md
+++ b/toolchain/specs/lithsec.md
@@ -1,0 +1,72 @@
+# `lithsec` implementation specification
+
+Status: reviewed specification only. The `lithsec` crate remains at `0.0.1` and
+must not claim that a contract was scanned or found safe. This matches the
+original toolchain target, which lists the capability and storage safety scanner
+as specification-only in this scaffold.
+
+## Required owner inputs
+
+Implementation is blocked until the Lithic/compiler, LithoVM, and security owners
+approve a versioned threat model containing:
+
+- the supported Lithic language and bytecode versions;
+- capability creation, delegation, revocation, and authorization semantics;
+- storage visibility, aliasing, initialization, mutation, growth, and upgrade
+  semantics;
+- external/internal call, callback, await, atomicity, revert, and reentrancy
+  behavior;
+- AI primitive capability, budget, charging, failure, and result-trust rules;
+- privileged lifecycle operations and whether EVM-compatible low-level operations
+  exist in the supported language;
+- rule identifiers, severity, confidence, suppression, baseline, and versioning
+  policy;
+- the accepted false-positive and false-negative thresholds for each rule.
+
+No Solidity keyword, EVM opcode, authorization pattern, state-write pattern, or
+async/reentrancy relationship may be inferred without that approved model.
+
+## Minimum implementation boundary
+
+A future implementation may be called a security scanner only when it:
+
+1. consumes typed compiler IR and resolved call/storage/capability information,
+   not raw body substrings;
+2. identifies comments, literals, identifiers, operators, calls, assignments,
+   effects, and control-flow paths structurally;
+3. ties every finding to an approved, versioned rule with a real source span,
+   severity, confidence, explanation, and actionable remediation;
+4. distinguishes proven findings from heuristics and never reports “safe” merely
+   because no heuristic matched;
+5. validates suppression directives against an approved policy and records them
+   in machine-readable output;
+6. supports deterministic human and machine-readable output with stable exit
+   codes for findings, invalid input/configuration, and unavailable analysis;
+7. fails closed on unsupported compiler/IR versions or incomplete analysis;
+8. runs without RPC, key, network, or production-state access unless a separate
+   approved dynamic-analysis mode explicitly requires it.
+
+## Required verification
+
+- A security-owner-reviewed positive and negative fixture corpus for every rule.
+- Fixtures proving that comments, strings, similarly named identifiers, dead
+  code, guards unrelated to authorization, and unsupported syntax do not create
+  misleading results.
+- Interprocedural and path-sensitive fixtures for capability flow, storage
+  effects, callbacks, awaits, reverts, and privileged operations.
+- Stable rule/severity/suppression behavior across compiler and scanner versions.
+- Exact source spans including non-ASCII and generated/source-mapped code.
+- False-positive/negative measurements against the approved corpus and both
+  tracked Makalu Lithic contracts.
+- Deterministic Linux, Windows, and macOS output plus independent compiler and
+  security-owner acceptance.
+
+## Rejected draft boundary
+
+The local uncommitted draft reviewed on 2026-08-16 is not acceptable for release.
+It promotes the crate to `0.1.0` and applies SEC001–SEC005 with raw substring and
+line matching. It assumes unapproved Solidity/EVM constructs and Lithic runtime
+semantics, can match comments or literals, treats any `assert` as access control,
+and treats a textual state write after `await` as reentrancy evidence without
+typed control-flow or call analysis. None of that draft is included in this
+slice.


### PR DESCRIPTION
## Summary
- keep `lithsec` at `0.0.1` and specification-only, matching the original scaffold target
- explicitly reject `--scan` and source paths so heuristic output cannot be presented as a security result
- document the required threat model, typed-IR analysis, rule/version/suppression policy, corpus, false-result measurements, and independent acceptance gates
- add three fail-closed CLI tests and extend the three-OS formatting/Clippy gate

## Verification
- scoped `rustfmt --check`: passed
- `cargo check --workspace`: passed
- scoped Clippy with `-D warnings`: passed
- `git diff --check`: passed
- full tests/release linking require hosted Linux, Windows, and macOS jobs because this Windows host lacks `link.exe`

## Excluded draft
The uncommitted `0.1.0` SEC001-SEC005 raw-text scanner is excluded. It assumes unapproved EVM/Lithic semantics, can match comments/strings, treats any `assert` as access control, and infers reentrancy from text after `await` without typed flow analysis.

No security scan or release is claimed.