### PR TITLE
docs(makalu): record lithsec specification merge

### DIFF
--- a/docs/makalu-extra-works-handoff.md
+++ b/docs/makalu-extra-works-handoff.md
@@ -51,7 +51,7 @@ into a reviewable change, and never bulk-commit the dirty worktree.
 | MX-04 | DNNS | Verified explorer hardening merged and deployed; owner acceptance open | EXTERNAL BLOCKER | DNNS owner confirms the supported interface, fixes public docs, nominates a reverse record, and accepts cache policy. |
 | MX-05 | Quantt | Assumption-free gates deployed; adapter remains disabled | EXTERNAL BLOCKER | Quantt owner supplies the API contract/credential and fixes or replaces the development TLS endpoint. |
 | MX-01 | MultX / Lithoswap | V2 DEX and non-AWS signer hardening merged; swap disabled | IN PROGRESS | Obtain independent audit, operator, deployment, controller, and liquidity approvals. |
-| MX-07 | Developer toolchain | Front-end, formatter, linter, `lithls`/`lithtest` specs, and safe `lithdev` v0 merged; no deployable compiler/release | IN PROGRESS | Review `lithsec` next; approved language/VM semantics still block full compiler work. |
+| MX-07 | Developer toolchain | Front-end, formatter, linter, three spec-only tools, and safe `lithdev` v0 merged; no deployable compiler/release | IN PROGRESS | Review `lithpkg` next; approved language/VM semantics still block full compiler work. |
 
 ## Sequential closure queue
 
@@ -499,7 +499,7 @@ CI/release packaging. Those changes remain local-only. Review of the first share
 local semantic pass inferred an unapproved primitive-type table, overload behavior, map-key restrictions, and return
 semantics. PR #95 removed those assumptions, added only unambiguous declaration-name checks, introduced a three-OS
 CI gate, passed every gate, and merged as `cf68f7c001cd6a847f806cac09659bf72380bda2`. The tracked release still
-describes `lithsec` and `lithpkg` as spec-only stubs. `lithc` still does not
+describes `lithpkg` as a spec-only stub. `lithc` still does not
 parse/lower full function bodies into deployable LithoVM/EVM bytecode.
 
 | Tool | Local implementation | Required before full-release acceptance |
@@ -510,7 +510,7 @@ parse/lower full function bodies into deployable LithoVM/EVM bytecode.
 | `lithls` | Reviewed specification-only boundary on `main`; packaged stub explicitly refuses `--stdio` and does not advertise LSP support. | Product/release-owner acceptance of spec-only scope; any future server must meet the documented LSP 3.17/JSON-RPC conformance, real-span, three-OS, and editor gates. |
 | `lithdev` | Strict local Compose lifecycle, conservative declaration checks, read-only ABI output, and fail-closed deploy preflight on `main`. Destructive volume deletion is excluded. | Operator acceptance with a running local Docker engine; compiler bytecode, simulation, signing, broadcast, receipt verification, and safe account/network policy before real deploy support. |
 | `lithtest` | Reviewed specification-only boundary on `main`; packaged stub explicitly refuses `--run` and source paths, so raw body text cannot be reported as executed tests. | Approved test syntax plus typed compiler/LithoVM execution, fixtures/isolation, failure traces, gas/coverage decisions, conformance suite, and release-owner acceptance. |
-| `lithsec` | SEC001–SEC005 capability/storage checks. | Threat-model review, fixtures, severity/suppression policy, and false-positive/negative acceptance. |
+| `lithsec` | Reviewed specification-only boundary on `main`; packaged stub explicitly refuses `--scan` and source paths, so heuristics cannot be presented as security results. | Approved threat model, typed-IR analysis, rule/version/severity/suppression policy, positive/negative corpus, false-result measurements, and independent compiler/security acceptance. |
 | `lithpkg` | Local manifests, local dependencies, and deterministic locks. | Decide whether local-only v0 is accepted; otherwise specify and implement a signed registry and trust policy. |
 
 Completed or evidenced locally:
@@ -551,11 +551,16 @@ Completed or evidenced locally:
 - [x] PR #105 kept `lithtest` at `0.0.1`, made execution fail closed, documented the syntax/compiler/VM/isolation
       gates, passed all 34 Rust tests and full release builds on Linux, Windows, and macOS, and merged as
       `b0e5372a71de2c08bafa0b9d0cb48c4ff5ce3ea9` (2026-08-16).
+- [x] Rejected the uncommitted `lithsec` `0.1.0` text scanner because it inferred unapproved EVM/Lithic semantics,
+      could match comments/literals, treated any assertion as access control, and lacked typed flow analysis.
+- [x] PR #107 kept `lithsec` at `0.0.1`, made scanning fail closed, documented the threat-model/typed-analysis and
+      false-result acceptance gates, passed all 37 Rust tests and full release builds on Linux, Windows, and macOS,
+      and merged as `efca15c3d9f3b3c0dc3d0dd1241f7f02cb90c371` (2026-08-16).
 
 Remaining actions:
 
 - [x] Merge the reviewed shared syntax/`lithc` and CI slice after its Linux/Windows/macOS gates pass.
-- [ ] Separately review `lithsec`, `lithpkg`, release packaging,
+- [ ] Separately review `lithpkg`, release packaging,
       examples, and lockfile.
 - [x] Merge the `lithfmt` literal-safety fix after three-OS tests and release builds pass.
 - [ ] Record product/release-owner acceptance of the whitespace-only v0 formatter or implement the approved
@@ -660,8 +665,20 @@ Evidence:
 | 2026-08-16 | `lithls` specification review | MERGED | PR #101 retained the requested spec-only scope, made `--stdio` fail closed, excluded the non-conformant local server draft, and passed Linux, Windows, and macOS gates with all 23 Rust tests and full workspace release builds; merged as `9b8f304a`. |
 | 2026-08-16 | `lithdev` safe-v0 review | MERGED | PR #103 added bounded local Compose lifecycle, read-only declaration/ABI commands, and fail-closed deploy preflight; eight safety tests reject destructive or misleading behavior. All three OS gates passed with 31 Rust tests and full release builds; merged as `d6d1a26b`. |
 | 2026-08-16 | `lithtest` specification review | MERGED | PR #105 retained the requested spec-only scope, made execution fail closed, excluded the raw-body assertion scanner, and passed Linux, Windows, and macOS gates with all 34 Rust tests and full workspace release builds; merged as `b0e5372a`. |
+| 2026-08-16 | `lithsec` specification review | MERGED | PR #107 retained the requested spec-only scope, made scanning fail closed, excluded the unapproved SEC001–SEC005 text heuristics, and passed Linux, Windows, and macOS gates with all 37 Rust tests and full workspace release builds; merged as `efca15c3`. |
 
 ## Change log
+
+### 2026-08-16 — MX-07 `lithsec` specification boundary merged
+
+- PR #107 passed both workflow trigger sets on Linux, Windows, and macOS: scoped formatting and Clippy with warnings
+  denied, all 37 Rust tests, full workspace release builds, and the `lithc` smoke check.
+- All standard repository gates passed; PR #107 merged by `bachal-mb` as
+  `efca15c3d9f3b3c0dc3d0dd1241f7f02cb90c371`.
+- The crate remains `0.0.1` and specification-only as requested. It refuses scanning until the threat model,
+  typed-IR analysis, rule/severity/suppression policy, corpus, and false-result thresholds are approved.
+- The local SEC001–SEC005 raw-text draft was excluded; no contract was scanned or reported safe.
+- Updated by: `bachal-mb`.
 
 ### 2026-08-16 — MX-07 `lithtest` specification boundary merged
 


### PR DESCRIPTION
## Summary
- record PR #107 and exact merge commit
- record the 37-test Linux, Windows, and macOS evidence
- mark the requested `lithsec` specification-only repository slice reviewed
- retain threat-model, typed analysis, rule policy, corpus, false-result, and independent security acceptance as explicit gates
- advance MX-07 to `lithpkg`

No contract security scan or release is claimed.