### PR TITLE
docs(toolchain): define honest lithpkg boundary

### DIFF
--- a/.github/workflows/ci-toolchain.yaml
+++ b/.github/workflows/ci-toolchain.yaml
@@ -49,8 +49,10 @@ jobs:
           crates/lithtest/tests/cli.rs
           crates/lithsec/src/main.rs
           crates/lithsec/tests/cli.rs
-      - name: Lints (reviewed front-end slice)
-        run: cargo clippy -p lithic-syntax -p lithc -p lithfmt -p lithlint -p lithls -p lithdev -p lithtest -p lithsec --all-targets -- -D warnings
+          crates/lithpkg/src/main.rs
+          crates/lithpkg/tests/cli.rs
+      - name: Lints (reviewed workspace)
+        run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Tests
         run: cargo test --workspace
       - name: Release build

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -19,7 +19,7 @@ the parser is tested against as golden files.
 | `lithdev`  | **real (bounded v0)** | Strict local Compose lifecycle, declaration checks, read-only ABI output, and fail-closed deploy preflight. Volume deletion, signing, broadcast, and receipt claims are excluded. |
 | `lithtest` | **reviewed spec-only** | Explicitly refuses `--run`; the syntax-owner, compiler/VM, isolation, failure, conformance, and acceptance boundary is in [`specs/lithtest.md`](specs/lithtest.md). |
 | `lithsec`  | **reviewed spec-only** | Explicitly refuses `--scan`; the threat-model, typed-analysis, rule, corpus, false-result, conformance, and acceptance boundary is in [`specs/lithsec.md`](specs/lithsec.md). |
-| `lithpkg`  | spec-only stub | Package manager. |
+| `lithpkg`  | **reviewed spec-only** | Explicitly refuses `--resolve`; the manifest, resolver, integrity, trust, filesystem, atomicity, compiler-integration, conformance, and acceptance boundary is in [`specs/lithpkg.md`](specs/lithpkg.md). |
 
 The shared crate `lithic-syntax` holds the lexer, parser, AST and diagnostics;
 every tool builds on it.

--- a/toolchain/crates/lithpkg/src/main.rs
+++ b/toolchain/crates/lithpkg/src/main.rs
@@ -1,15 +1,49 @@
-//! `lithpkg` — Lithic package manager. Spec-only stub.
+//! `lithpkg` — Lithic package-manager specification marker.
 
-fn main() {
+use std::process::ExitCode;
+
+const STATUS: &str =
+    "lithpkg is specification-only in this scaffold; no package operation is performed";
+
+fn print_help() {
     println!(
-        "lithpkg {} — Lithic package manager (SPEC-ONLY, not yet implemented)\n\
+        "lithpkg {} — Lithic package manager (specification-only)\n\
 \n\
-Planned responsibilities:\n\
-  * `lithpkg.toml` manifests with semver dependency resolution\n\
-  * fetch/vendor reusable Lithic modules (e.g. LEP100 standards library)\n\
-  * lockfile + reproducible builds, integrated with lithc include paths\n\
+USAGE:\n\
+    lithpkg [--help | --version | --resolve]\n\
 \n\
-This binary currently exits without managing packages. See toolchain/README.md.",
+OPTIONS:\n\
+    --resolve  Fail explicitly because package resolution is unavailable\n\
+    --version  Print the package version\n\
+    -h, --help Print this help\n\
+\n\
+See toolchain/specs/lithpkg.md for the reviewed implementation boundary.",
         env!("CARGO_PKG_VERSION")
     );
+}
+
+fn main() -> ExitCode {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    match args.as_slice() {
+        [] => {
+            println!("{STATUS}");
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "-h" || arg == "--help" => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--version" => {
+            println!("lithpkg {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        [arg] if arg == "--resolve" => {
+            eprintln!("lithpkg: unavailable: {STATUS}");
+            ExitCode::from(3)
+        }
+        _ => {
+            eprintln!("lithpkg: error: unsupported arguments");
+            ExitCode::from(2)
+        }
+    }
 }

--- a/toolchain/crates/lithpkg/tests/cli.rs
+++ b/toolchain/crates/lithpkg/tests/cli.rs
@@ -1,0 +1,40 @@
+use std::process::Command;
+
+#[test]
+fn reports_the_package_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithpkg"))
+        .arg("--version")
+        .output()
+        .expect("run lithpkg");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "lithpkg 0.0.1\n");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn resolve_mode_fails_instead_of_writing_an_untrusted_lockfile() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithpkg"))
+        .arg("--resolve")
+        .output()
+        .expect("run lithpkg");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no package operation is performed"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn manifest_paths_are_rejected_until_the_format_is_approved() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lithpkg"))
+        .arg("lithpkg.toml")
+        .output()
+        .expect("run lithpkg");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unsupported arguments"));
+}

--- a/toolchain/specs/lithpkg.md
+++ b/toolchain/specs/lithpkg.md
@@ -1,0 +1,76 @@
+# `lithpkg` implementation specification
+
+Status: reviewed specification only. The `lithpkg` crate remains at `0.0.1` and
+must not initialize packages, resolve dependencies, write lockfiles, fetch code,
+or claim reproducibility. This matches the original toolchain target, which lists
+the package manager as specification-only in this scaffold.
+
+## Required owner inputs
+
+Implementation is blocked until the Lithic/compiler, release, and security owners
+approve:
+
+- the manifest and lockfile names, grammars, schemas, and versioning rules;
+- package/module naming, source layout, import resolution, features, targets, and
+  compiler include/module integration;
+- the exact version and version-requirement standard;
+- resolver behavior for transitive dependencies, duplicates, conflicts, cycles,
+  optional dependencies, platform conditions, and prereleases;
+- whether v0 is local-path-only or includes a registry, Git, archive, or other
+  source types;
+- registry ownership, authentication, authorization, namespace, immutability,
+  signing, transparency, revocation, yanking, retention, and incident policy;
+- the artifact digest/signature algorithms and canonical bytes they cover;
+- offline, vendoring, cache, mirror, proxy, and reproducible-build behavior.
+
+No TOML subset, semantic-version subset, default package version, registry, hash,
+or trust policy may be inferred without those approvals.
+
+## Minimum implementation boundary
+
+A future implementation may be called a package manager only when it:
+
+1. parses the approved manifest/lock schemas with a conforming parser and rejects
+   unknown, duplicate, malformed, or unsupported fields deterministically;
+2. performs complete deterministic dependency resolution, including transitive
+   graphs, conflicts, cycles, aliases, and source identity;
+3. canonicalizes and constrains local paths, handles symlinks explicitly, and
+   prevents unintended traversal outside the approved package/workspace boundary;
+4. uses an approved cryptographic digest and, where required, verifies publisher
+   identity, signatures, provenance, and immutable source content;
+5. writes manifests, source scaffolds, caches, and lockfiles atomically without
+   overwriting existing user files or leaving partial packages;
+6. records enough canonical source, version, digest, feature, target, and resolver
+   metadata for reproducible offline builds;
+7. feeds only locked, verified module roots into the approved compiler import
+   resolver and detects package/module name collisions;
+8. separates read-only check/resolve operations from mutating init/fetch/update
+   operations and supports dry-run output for every mutation;
+9. fails closed on unsupported schema, source, signature, digest, compiler, or
+   lockfile versions.
+
+## Required verification
+
+- Manifest and lockfile conformance fixtures, including comments, escapes,
+  Unicode, duplicates, unknown fields, malformed values, and schema upgrades.
+- Resolver fixtures for diamond graphs, conflicts, cycles, aliases, prereleases,
+  optional/platform dependencies, source changes, and deterministic ordering.
+- Filesystem fixtures for absolute/relative paths, `..`, symlinks, junctions,
+  case sensitivity, non-UTF-8 names where supported, and workspace escape attempts.
+- Integrity fixtures for tampering, digest/signature mismatch, revocation, yanking,
+  offline cache use, and source identity substitution.
+- Crash/interruption and atomicity tests proving existing files are preserved and
+  partial state is recoverable.
+- Repeated clean/offline builds producing identical locks and compiler inputs on
+  Linux, Windows, and macOS.
+- Independent compiler, supply-chain security, and release-owner acceptance.
+
+## Rejected draft boundary
+
+The local uncommitted draft reviewed on 2026-08-16 is not acceptable for release.
+It promotes the crate to `0.1.0`, hand-parses a TOML-like subset, treats three
+numeric components as complete semantic-version validation, resolves only direct
+local paths, lacks graph/cycle/path/symlink controls, and labels a 64-bit FNV-1a
+value as a package checksum. Its init and lock operations write non-atomically and
+are not integrated with an approved compiler import resolver. None of that draft
+is included in this slice.


### PR DESCRIPTION
## Summary
- keep `lithpkg` at `0.0.1` and specification-only, matching the original scaffold target
- explicitly reject `--resolve` and manifest paths so no untrusted lockfile/package state is written
- document manifest/schema, resolver, integrity, trust, filesystem, atomicity, compiler integration, conformance, and acceptance gates
- add three fail-closed CLI tests
- promote the CI lint gate to full-workspace Clippy with warnings denied now that all eight public binaries have been reviewed

## Verification
- targeted `rustfmt --check`: passed
- `cargo check --workspace`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `git diff --check`: passed
- full tests/release linking require hosted Linux, Windows, and macOS jobs because this Windows host lacks `link.exe`

## Excluded draft
The uncommitted `0.1.0` local package manager is excluded. It hand-parses a TOML-like subset, implements incomplete version/graph resolution, lacks path/symlink/cycle controls, uses a non-cryptographic 64-bit FNV value as a checksum, and writes non-atomically without approved compiler integration.

No package operation or release is claimed.