### PR TITLE
feat(multx): add isolated AWS Fargate KMS verifiers

### DIFF
--- a/MultX/api/Dockerfile.fargate-signer
+++ b/MultX/api/Dockerfile.fargate-signer
@@ -1,0 +1,16 @@
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev \
+    && addgroup -S multx \
+    && adduser -S -G multx -h /app multx
+
+COPY --chown=multx:multx src/fargateSignerWorker.js ./src/fargateSignerWorker.js
+COPY --chown=multx:multx src/services/kmsSigner.js ./src/services/kmsSigner.js
+USER multx
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/health | grep -q '"status":"ok"'
+
+CMD ["node", "src/fargateSignerWorker.js"]

--- a/MultX/api/package-lock.json
+++ b/MultX/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-kms": "^3.1049.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "ethers": "^6.17.0",
@@ -24,6 +25,278 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1111.0.tgz",
+      "integrity": "sha512-vs7v+BWPp7CBvcZ6Dp4LwseZ4M0ERCICsheNAyabvnAuL+qPo4FNIm2TILZ18amN737+V2XqKuDelsePthd91A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -64,6 +337,87 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.7.5",
@@ -128,6 +482,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",

--- a/MultX/api/package.json
+++ b/MultX/api/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-kms": "^3.1049.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "ethers": "^6.17.0",

--- a/MultX/api/src/fargateSignerWorker.js
+++ b/MultX/api/src/fargateSignerWorker.js
@@ -1,0 +1,47 @@
+import { createServer } from 'node:http';
+import { getBytes, verifyMessage } from 'ethers';
+import { kmsKeyAddress, kmsSignMessage } from './services/kmsSigner.js';
+
+if (process.env.SIGNER_VERIFY_ONLY !== 'true' || process.env.VALIDATOR_SIGNING_ENABLED !== 'false') {
+  throw new Error('Fargate verification image refuses to start outside transaction-free verification mode');
+}
+
+const keyId = process.env.VALIDATOR_KMS_KEY_ARN;
+if (!keyId) throw new Error('VALIDATOR_KMS_KEY_ARN is required');
+
+const address = await kmsKeyAddress(keyId);
+const expected = process.env.EXPECTED_SIGNER_ADDRESS;
+if (expected && expected.toLowerCase() !== address.toLowerCase()) {
+  throw new Error(`KMS signer ${address} does not match EXPECTED_SIGNER_ADDRESS`);
+}
+
+const challenge = getBytes(Buffer.from('MultX Fargate signer transaction-free verification v1'));
+const signature = await kmsSignMessage({ keyId, message: challenge, expectedAddress: address });
+const recovered = verifyMessage(challenge, signature);
+if (recovered.toLowerCase() !== address.toLowerCase()) {
+  throw new Error(`verification recovered ${recovered}, expected ${address}`);
+}
+
+console.log(`[FargateSigner] Transaction-free KMS verification passed for ${address}`);
+
+const server = createServer((request, response) => {
+  if (request.method !== 'GET' || request.url !== '/health') {
+    response.writeHead(404).end();
+    return;
+  }
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ status: 'ok', mode: 'verification-only', address }));
+});
+
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(8080, '127.0.0.1', resolve);
+});
+console.log('[FargateSigner] Verification-only mode ready; transactions and database access are disabled');
+
+const shutdown = (signal) => {
+  console.log(`[FargateSigner] ${signal} received; shutting down`);
+  server.close(() => process.exit(0));
+};
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/MultX/api/src/services/kmsSigner.js
+++ b/MultX/api/src/services/kmsSigner.js
@@ -1,0 +1,68 @@
+import { GetPublicKeyCommand, KMSClient, SignCommand } from '@aws-sdk/client-kms';
+import { getAddress, hashMessage, keccak256, recoverAddress } from 'ethers';
+
+const CURVE_N = BigInt('0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141');
+const HALF_N = CURVE_N >> 1n;
+const clients = new Map();
+
+const clientFor = (region) => {
+  const selected = region || process.env.AWS_REGION || 'us-east-1';
+  if (!clients.has(selected)) clients.set(selected, new KMSClient({ region: selected }));
+  return clients.get(selected);
+};
+
+const readDerLength = (bytes, offset) => {
+  const first = bytes[offset];
+  if (first < 0x80) return { length: first, next: offset + 1 };
+  const count = first & 0x7f;
+  if (count < 1 || count > 2) throw new Error('unsupported DER length');
+  let length = 0;
+  for (let i = 0; i < count; i += 1) length = (length << 8) | bytes[offset + 1 + i];
+  return { length, next: offset + 1 + count };
+};
+
+const decodeInteger = (bytes, offset) => {
+  if (bytes[offset] !== 0x02) throw new Error('invalid DER integer');
+  const { length, next } = readDerLength(bytes, offset + 1);
+  const value = bytes.slice(next, next + length);
+  if (value.length === 0 || next + length > bytes.length) throw new Error('truncated DER integer');
+  return { value: BigInt(`0x${Buffer.from(value).toString('hex') || '0'}`), next: next + length };
+};
+
+const decodeSignature = (input) => {
+  const bytes = Buffer.from(input);
+  if (bytes[0] !== 0x30) throw new Error('invalid DER signature sequence');
+  const sequence = readDerLength(bytes, 1);
+  if (sequence.next + sequence.length !== bytes.length) throw new Error('invalid DER signature length');
+  const r = decodeInteger(bytes, sequence.next);
+  const s = decodeInteger(bytes, r.next);
+  if (s.next !== bytes.length) throw new Error('unexpected DER signature data');
+  return { r: r.value, s: s.value > HALF_N ? CURVE_N - s.value : s.value };
+};
+
+const word = (value) => value.toString(16).padStart(64, '0');
+
+export const kmsKeyAddress = async (keyId, region) => {
+  const response = await clientFor(region).send(new GetPublicKeyCommand({ KeyId: keyId }));
+  if (!response.PublicKey) throw new Error('KMS GetPublicKey returned no public key');
+  const point = Buffer.from(response.PublicKey).subarray(-65);
+  if (point.length !== 65 || point[0] !== 0x04) throw new Error('KMS key is not an uncompressed secp256k1 key');
+  return getAddress(`0x${keccak256(point.subarray(1)).slice(-40)}`);
+};
+
+export const kmsSignMessage = async ({ keyId, message, expectedAddress, region }) => {
+  const digest = hashMessage(message);
+  const response = await clientFor(region).send(new SignCommand({
+    KeyId: keyId,
+    Message: Buffer.from(digest.slice(2), 'hex'),
+    MessageType: 'DIGEST',
+    SigningAlgorithm: 'ECDSA_SHA_256',
+  }));
+  if (!response.Signature) throw new Error('KMS Sign returned no signature');
+  const { r, s } = decodeSignature(response.Signature);
+  for (const v of [27, 28]) {
+    const signature = `0x${word(r)}${word(s)}${v.toString(16)}`;
+    if (recoverAddress(digest, signature).toLowerCase() === expectedAddress.toLowerCase()) return signature;
+  }
+  throw new Error('KMS signature does not recover the expected signer address');
+};

--- a/MultX/docs/FARGATE_SIGNER_ARCHITECTURE.md
+++ b/MultX/docs/FARGATE_SIGNER_ARCHITECTURE.md
@@ -1,0 +1,43 @@
+# MultX AWS Fargate signer architecture
+
+Status: verification-only. This package must not be used to authorize bridge
+transactions until the audit and activation gates are approved.
+
+## Design
+
+MultX uses seven ECS Fargate services and seven non-exportable AWS KMS
+`ECC_SECG_P256K1` keys. Each service receives a distinct ECS task role whose
+policy grants `kms:GetPublicKey`, `kms:DescribeKey`, and `kms:Sign` on exactly
+one key. The configured threshold remains 5-of-7.
+
+Native ECS task credentials replace IAM Roles Anywhere for these workloads.
+No CA, client certificate, permanent AWS access key, plaintext validator key,
+or signer bearer token is required.
+
+The current container is intentionally transaction-free. It derives the KMS
+public address, signs a fixed verification challenge, verifies address
+recovery, exposes a loopback-only health endpoint, and then remains idle. It
+fails startup unless `SIGNER_VERIFY_ONLY=true` and
+`VALIDATOR_SIGNING_ENABLED=false`.
+
+## Source and deployment
+
+- Image: `MultX/api/Dockerfile.fargate-signer`
+- Worker: `MultX/api/src/fargateSignerWorker.js`
+- KMS adapter: `MultX/api/src/services/kmsSigner.js`
+- Production provisioning, resource mappings, and verification evidence are
+  maintained in the private `KaJLabs/Lithosphere-Production-Infra`
+  repository.
+
+Production deployment must use an immutable ECR digest and the approved AWS
+account and region. Infrastructure changes require review and an approved
+change window.
+
+## Production activation boundary
+
+The verification worker does not implement bridge transaction signing. Before
+adding that capability, the reviewed design must provide independent lock
+verification, durable anti-equivocation state, authenticated private API
+connectivity, monitoring and rollback. The final implementation and contracts
+must pass the independent security audit and fix review before MultX is
+enabled.


### PR DESCRIPTION
## Summary

- adds the canonical transaction-free AWS KMS verifier used by seven isolated ECS Fargate services
- adds a pinned, rootless, read-only verification image
- documents the public Fargate/KMS architecture and strict production activation boundary

Production provisioning, resource mappings, and verification evidence are maintained in the private `KaJLabs/Lithosphere-Production-Infra` repository.

## Verification

- `MultX/api`: 18/18 Node tests passed
- `npm audit`: 0 vulnerabilities
- live transaction-free KMS signing/recovery passed for all seven configured signers
- IAM isolation validation passed with no cross-key access
- all seven ECS verifier tasks were healthy after deployment
- ECR image scan completed with zero findings

## Safety boundary

This worker refuses to start unless verification-only mode is enabled and transaction signing is disabled. It has no database or bridge-transaction path. MultX remains disabled; this PR does not authorize contracts, transactions, validator rotation, or production activation. Audit/fix review and the remaining activation gates still apply.