### PR TITLE
feat(multx): add disabled Fargate production signer candidate

### DIFF
--- a/MultX/api/.env.example
+++ b/MultX/api/.env.example
@@ -46,6 +46,9 @@ VALIDATOR_SIGNER_ADDRESS_0=
 VALIDATOR_SIGNER_CA_FILE_0=/run/secrets/multx_signer_0_ca
 VALIDATOR_SIGNER_CERT_FILE_0=/run/secrets/multx_signer_0_client_cert
 VALIDATOR_SIGNER_KEY_FILE_0=/run/secrets/multx_signer_0_client_key
+# Alternative for an internal TLS load balancer in front of a Fargate signer.
+# Do not configure client cert/key when this bearer-token file is used.
+VALIDATOR_SIGNER_TOKEN_FILE_0=
 VALIDATOR_SIGNER_TIMEOUT_MS=8000
 
 # Local development only; rejected when NODE_ENV=production:

--- a/MultX/api/src/services/remoteSigner.js
+++ b/MultX/api/src/services/remoteSigner.js
@@ -11,6 +11,34 @@ const requiredFile = (path, label) => {
   return value;
 };
 
+const bearerToken = (path, label) => {
+  const token = requiredFile(path, label).toString('utf8').trim();
+  if (token.length < 32 || token.length > 512 || /[\r\n]/.test(token)) {
+    throw new Error(`${label} must contain 32 to 512 characters`);
+  }
+  return token;
+};
+
+export const resolveRemoteSignerAuth = ({ index, caFile, certFile, keyFile, tokenFile }) => {
+  if (tokenFile) {
+    if (certFile || keyFile) throw new Error(`remote signer ${index} must use bearer or mTLS client credentials, not both`);
+    return {
+      mode: 'bearer',
+      token: bearerToken(tokenFile, `VALIDATOR_SIGNER_TOKEN_FILE_${index}`),
+      tls: { ...(caFile ? { ca: requiredFile(caFile, `VALIDATOR_SIGNER_CA_FILE_${index}`) } : {}) },
+    };
+  }
+  return {
+    mode: 'mtls',
+    token: null,
+    tls: {
+      ca: requiredFile(caFile, `VALIDATOR_SIGNER_CA_FILE_${index}`),
+      cert: requiredFile(certFile, `VALIDATOR_SIGNER_CERT_FILE_${index}`),
+      key: requiredFile(keyFile, `VALIDATOR_SIGNER_KEY_FILE_${index}`),
+    },
+  };
+};
+
 export const validateSignerUrl = (value) => {
   let url;
   try { url = new URL(value); } catch { throw new Error('remote signer URL must be valid'); }
@@ -24,7 +52,7 @@ export const validateSignerUrl = (value) => {
   return url.origin;
 };
 
-const requestJson = ({ baseUrl, path, method, body, tls, timeoutMs }) => new Promise((resolve, reject) => {
+const requestJson = ({ baseUrl, path, method, body, tls, token, timeoutMs }) => new Promise((resolve, reject) => {
   const url = new URL(path, baseUrl);
   if (url.protocol !== 'https:') {
     reject(new Error(`remote signer URL must use https (got ${url.protocol})`));
@@ -46,6 +74,7 @@ const requestJson = ({ baseUrl, path, method, body, tls, timeoutMs }) => new Pro
     timeout: timeoutMs,
     headers: {
       accept: 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
       ...(payload ? {
         'content-type': 'application/json',
         'content-length': String(payload.length),
@@ -112,21 +141,19 @@ export const createRemoteSigner = async ({
   caFile,
   certFile,
   keyFile,
+  tokenFile,
   timeoutMs = 8_000,
 }) => {
   const address = ethers.getAddress(expectedAddress);
   const baseUrl = validateSignerUrl(url);
-  const tls = {
-    ca: requiredFile(caFile, `VALIDATOR_SIGNER_CA_FILE_${index}`),
-    cert: requiredFile(certFile, `VALIDATOR_SIGNER_CERT_FILE_${index}`),
-    key: requiredFile(keyFile, `VALIDATOR_SIGNER_KEY_FILE_${index}`),
-  };
+  const auth = resolveRemoteSignerAuth({ index, caFile, certFile, keyFile, tokenFile });
 
   const identity = await requestJson({
     baseUrl,
     path: '/v1/identity',
     method: 'GET',
-    tls,
+    tls: auth.tls,
+    token: auth.token,
     timeoutMs,
   });
   const reported = ethers.getAddress(identity.address || '');
@@ -144,7 +171,8 @@ export const createRemoteSigner = async ({
         path: '/v1/sign-release',
         method: 'POST',
         body: { version: 1, ...attestation },
-        tls,
+        tls: auth.tls,
+        token: auth.token,
         timeoutMs,
       });
       if (typeof response.signature !== 'string') {

--- a/MultX/api/src/services/validatorService.js
+++ b/MultX/api/src/services/validatorService.js
@@ -33,6 +33,7 @@ async function loadValidators(timeoutMs) {
         caFile: process.env[`VALIDATOR_SIGNER_CA_FILE_${i}`],
         certFile: process.env[`VALIDATOR_SIGNER_CERT_FILE_${i}`],
         keyFile: process.env[`VALIDATOR_SIGNER_KEY_FILE_${i}`],
+        tokenFile: process.env[`VALIDATOR_SIGNER_TOKEN_FILE_${i}`],
         timeoutMs,
       }));
     } catch (err) {
@@ -69,7 +70,7 @@ export async function startValidatorService() {
   if (validators.length === 0) {
     throw new Error(
       '[ValidatorService] No validator signers found. Production requires ' +
-      'VALIDATOR_SIGNER_URL_0..N plus address and mTLS file settings. ' +
+      'VALIDATOR_SIGNER_URL_0..N plus address and bearer-token or mTLS settings. ' +
       'Local development may use VALIDATOR_PRIVATE_KEY_FILE_0..N or MOCK_VALIDATOR=true.'
     );
   }

--- a/MultX/api/test/remoteSigner.test.js
+++ b/MultX/api/test/remoteSigner.test.js
@@ -1,8 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { ethers } from 'ethers';
 import {
   releaseMessageHash,
+  resolveRemoteSignerAuth,
   validateSignerUrl,
   verifyReleaseSignature,
 } from '../src/services/remoteSigner.js';
@@ -41,6 +45,21 @@ test('accepts only credential-free HTTPS signer origins', () => {
     'https://signer-0.internal:9443?token=secret',
   ]) {
     assert.throws(() => validateSignerUrl(url));
+  }
+});
+
+test('loads a bearer token from a file without requiring client key material', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'multx-remote-auth-'));
+  const tokenFile = path.join(directory, 'token');
+  fs.writeFileSync(tokenFile, 'a-secure-test-token-that-is-at-least-32-characters');
+  try {
+    const auth = resolveRemoteSignerAuth({ index: 0, tokenFile });
+    assert.equal(auth.mode, 'bearer');
+    assert.match(auth.token, /^a-secure-test-token/);
+    assert.deepEqual(auth.tls, {});
+    assert.throws(() => resolveRemoteSignerAuth({ index: 0, tokenFile, certFile: tokenFile }), /not both/);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
   }
 });
 

--- a/MultX/docs/FARGATE_PRODUCTION_SIGNER_CANDIDATE.md
+++ b/MultX/docs/FARGATE_PRODUCTION_SIGNER_CANDIDATE.md
@@ -1,0 +1,80 @@
+# MultX Fargate production signer candidate
+
+Status: build and transaction-free preflight only. MultX and release signing
+remain disabled.
+
+## Trust boundaries
+
+Each of the seven signers has a distinct ECS service, task role, KMS key,
+DynamoDB decision table, bearer-token secret, target group, and security-group
+path. No task role may access another signer's key, decision table, or token.
+The intended contract threshold is 5-of-7, but contract rotation is a separate
+audited change.
+
+The API reaches each signer through a private HTTPS endpoint. TLS terminates at
+an internal load balancer. Only the load-balancer security group may reach the
+signer container. The application additionally requires a unique bearer token
+for `/v1/identity` and `/v1/sign-release`. The health endpoint contains no
+secret or signing operation.
+
+## Minimum signer task-role permissions
+
+Scope every statement to that signer's single KMS key or DynamoDB table.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "UseAssignedSigningKey",
+      "Effect": "Allow",
+      "Action": ["kms:GetPublicKey", "kms:Sign"],
+      "Resource": "KMS_KEY_ARN"
+    },
+    {
+      "Sid": "UseAssignedDecisionTable",
+      "Effect": "Allow",
+      "Action": ["dynamodb:DescribeTable", "dynamodb:PutItem"],
+      "Resource": "DYNAMODB_TABLE_ARN"
+    }
+  ]
+}
+```
+
+The ECS execution role—not the signer task role—handles ECR image pulls,
+CloudWatch log delivery, and retrieval of the one bearer-token secret declared
+in the task definition. Restrict `secretsmanager:GetSecretValue` to that
+secret. No AWS access key is embedded or stored.
+
+No TOTP seed workflow exists in this signer, so no TOTP KMS key or encrypt/
+decrypt permission is required.
+
+## Signing controls
+
+Before every signature, the signer independently:
+
+1. validates the request against its local source/route policy;
+2. checks the RPC-reported source chain ID;
+3. requires the configured confirmation depth;
+4. queries and matches the exact `TokensLocked` event;
+5. recomputes the release hash;
+6. conditionally records `(sourceChain, sourceNonce) -> hash` in DynamoDB; and
+7. asks only its assigned KMS key to sign the recomputed hash.
+
+The conditional DynamoDB write happens before KMS signing and rejects a
+different hash for an existing decision key. This provides durable
+anti-equivocation across task replacement and concurrent requests.
+
+## Fail-closed activation
+
+`SIGNER_RELEASE_SIGNING_ENABLED` defaults to false. While false, the signing
+route returns HTTP 503 and cannot reach RPC, DynamoDB decision writes, or KMS
+transaction signing. Startup performs only a fixed transaction-free KMS
+signature/recovery check and a DynamoDB table/schema readiness check.
+
+Enabling signing requires all of the following outside this code change:
+
+- independent security audit and accepted fix review;
+- approved contracts, routes, caps, governance and 5-of-7 signer set;
+- private endpoint, secret, monitoring, backup and rollback validation;
+- transaction-free canary and explicit production change approval.

--- a/MultX/signer/.dockerignore
+++ b/MultX/signer/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+test
+coverage
+.env
+.env.*
+*.log

--- a/MultX/signer/Dockerfile.fargate
+++ b/MultX/signer/Dockerfile.fargate
@@ -1,0 +1,16 @@
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev \
+    && addgroup -S multx \
+    && adduser -S -G multx -h /app multx
+
+COPY --chown=multx:multx src ./src
+USER multx
+
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/health | grep -q '"status":"healthy"'
+
+CMD ["node", "src/index.js"]

--- a/MultX/signer/README.md
+++ b/MultX/signer/README.md
@@ -1,9 +1,15 @@
-# MultX independent VPS signer
+# MultX independent signer
 
-This service replaces the historical AWS KMS integration. Each bridge
-validator operates one hardened signer on a separate VPS and failure domain.
-The MultX API connects over TLS 1.3 with a client certificate; the validator
-private key never enters the API container or repository.
+The signer supports two isolated deployment modes:
+
+- an AWS ECS Fargate production candidate using one non-exportable KMS key and
+  one DynamoDB anti-equivocation table per signer; and
+- the existing file-key/mTLS mode for non-production rehearsal and independent
+  VPS operation.
+
+Production refuses file-backed keys. The MultX API connects through a private
+TLS load balancer using a bearer token injected from the secret manager. The
+KMS private key never leaves AWS KMS or enters a container or repository.
 
 Deployment templates and operator acceptance steps are in
 [`compose.example.yaml`](./compose.example.yaml) and
@@ -22,7 +28,25 @@ The signer does not blindly sign an API-provided digest. For every request it:
    signing and rejects equivocation, including after restart; and
 7. returns an EIP-191 signature only after those checks pass.
 
-## Required mounted files
+## Fargate production-candidate configuration
+
+- `SIGNER_KMS_KEY_ARN`: one `ECC_SECG_P256K1` KMS key.
+- `SIGNER_DYNAMODB_TABLE`: a table whose partition key is the string
+  `decisionKey`.
+- `SIGNER_JOURNAL_BACKEND=dynamodb`.
+- `SIGNER_POLICY_JSON` or `SIGNER_POLICY_FILE`: reviewed route allowlist.
+- `SIGNER_TRANSPORT=proxy-http` and `SIGNER_BEHIND_TLS_PROXY=true`.
+- `SIGNER_BEARER_TOKEN` or `SIGNER_BEARER_TOKEN_FILE`: a 32-512 character
+  secret. In ECS, inject the environment value from Secrets Manager; never
+  put the value in a task definition or repository.
+- `SIGNER_RELEASE_SIGNING_ENABLED=false` until every activation gate passes.
+
+The load balancer must terminate HTTPS, add `X-Forwarded-Proto: https`, and
+be the only security-group source allowed to reach port 8080. `/health` is
+unauthenticated for load-balancer health checks; all identity and signing
+routes require the bearer token.
+
+## VPS rehearsal files
 
 - `SIGNER_PRIVATE_KEY_FILE`: validator ECDSA private key, readable only by the
   rootless container user.
@@ -32,7 +56,7 @@ The signer does not blindly sign an API-provided digest. For every request it:
 - `SIGNER_STATE_FILE`: persistent decision journal; defaults to
   `/var/lib/multx-signer/signed-releases.jsonl`.
 
-The host should use full-disk encryption, SSH-key-only administration, a
+The VPS host should use full-disk encryption, SSH-key-only administration, a
 default-deny firewall allowing port 9443 only from the MultX API VPS, offline
 encrypted key backup, log shipping and uptime alerts. Validator operators must
 not share VPS accounts, private keys or TLS server keys.

--- a/MultX/signer/package-lock.json
+++ b/MultX/signer/package-lock.json
@@ -8,6 +8,8 @@
       "name": "@litho/multx-signer",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1049.0",
+        "@aws-sdk/client-kms": "^3.1049.0",
         "ethers": "^6.17.0"
       }
     },
@@ -16,6 +18,343 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1111.0.tgz",
+      "integrity": "sha512-rji6S5ZJfBp3ahC7pcEilaBKDrnLNZGerIzXCEOhur9gkgMhTiJjpoQSLKgR1Lnehetew1isiciL9xVoNvt9uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/dynamodb-codec": "^3.973.43",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.29",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1111.0.tgz",
+      "integrity": "sha512-vs7v+BWPp7CBvcZ6Dp4LwseZ4M0ERCICsheNAyabvnAuL+qPo4FNIm2TILZ18amN737+V2XqKuDelsePthd91A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.43.tgz",
+      "integrity": "sha512-5nw01fhFJEKM68n0R65S1DijiSAQWZVbvH7IxTIJpFFbggg816jBVYvhK7W+XISjvtdg0rMkF/gQmuLGH713mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.29.tgz",
+      "integrity": "sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -41,6 +380,87 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -54,6 +474,12 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/ethers": {
@@ -83,6 +509,21 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.7.0",

--- a/MultX/signer/package.json
+++ b/MultX/signer/package.json
@@ -8,6 +8,8 @@
     "test": "node --test"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1049.0",
+    "@aws-sdk/client-kms": "^3.1049.0",
     "ethers": "^6.17.0"
   }
 }

--- a/MultX/signer/signer.env.example
+++ b/MultX/signer/signer.env.example
@@ -1,9 +1,13 @@
 NODE_ENV=production
-SIGNER_PORT=9443
-SIGNER_PRIVATE_KEY_FILE=/run/secrets/validator-key
-SIGNER_POLICY_FILE=/run/config/policy.json
-SIGNER_TLS_CERT_FILE=/run/tls/server.crt
-SIGNER_TLS_KEY_FILE=/run/tls/server.key
-SIGNER_CLIENT_CA_FILE=/run/tls/client-ca.crt
-SIGNER_STATE_FILE=/var/lib/multx-signer/signed-releases.jsonl
+AWS_REGION=us-east-1
+SIGNER_PORT=8080
+SIGNER_TRANSPORT=proxy-http
+SIGNER_BEHIND_TLS_PROXY=true
+SIGNER_KMS_KEY_ARN=arn:aws:kms:REGION:ACCOUNT_ID:key/KEY_ID
+SIGNER_DYNAMODB_TABLE=multx-production-signer-NN-decisions
+SIGNER_JOURNAL_BACKEND=dynamodb
+SIGNER_POLICY_JSON={"signerAddress":"0xSIGNER","sources":[]}
+SIGNER_BEARER_TOKEN=INJECT_FROM_AWS_SECRETS_MANAGER
 
+# Fail closed by default. Audit and activation approval are required before true.
+SIGNER_RELEASE_SIGNING_ENABLED=false

--- a/MultX/signer/src/auth.js
+++ b/MultX/signer/src/auth.js
@@ -1,0 +1,27 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+
+const normalizeToken = (value) => {
+  const token = String(value || '').trim();
+  if (token.length < 32 || token.length > 512 || /[\r\n]/.test(token)) {
+    throw new Error('signer bearer token must contain 32 to 512 characters');
+  }
+  return token;
+};
+
+export const loadBearerToken = ({ env = process.env } = {}) => {
+  const file = env.SIGNER_BEARER_TOKEN_FILE;
+  const inline = env.SIGNER_BEARER_TOKEN;
+  if (file && inline) throw new Error('configure bearer token file or environment value, never both');
+  if (file) return normalizeToken(fs.readFileSync(file, 'utf8'));
+  if (inline) return normalizeToken(inline);
+  throw new Error('signer bearer token is required');
+};
+
+export const hasValidBearerToken = (authorization, expectedToken) => {
+  const match = /^Bearer ([^\s]+)$/.exec(String(authorization || ''));
+  if (!match) return false;
+  const provided = Buffer.from(match[1]);
+  const expected = Buffer.from(expectedToken);
+  return provided.length === expected.length && crypto.timingSafeEqual(provided, expected);
+};

--- a/MultX/signer/src/dynamoJournal.js
+++ b/MultX/signer/src/dynamoJournal.js
@@ -1,0 +1,53 @@
+import { DescribeTableCommand, DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+
+const DECISION_KEY = /^[1-9][0-9]*:[1-9][0-9]*$/;
+const HASH = /^0x[0-9a-fA-F]{64}$/;
+
+const validateDecision = (key, hash) => {
+  if (!DECISION_KEY.test(key) || !HASH.test(hash)) {
+    throw new Error('invalid signing journal decision');
+  }
+};
+
+export const createDynamoDecisionJournal = ({
+  tableName,
+  signerAddress,
+  region,
+  client = new DynamoDBClient({ region: region || process.env.AWS_REGION || 'us-east-1' }),
+}) => {
+  if (!tableName) throw new Error('SIGNER_DYNAMODB_TABLE is required');
+  if (!signerAddress) throw new Error('signer address is required for DynamoDB journal');
+
+  return {
+    async assertReady() {
+      const response = await client.send(new DescribeTableCommand({ TableName: tableName }));
+      if (response.Table?.TableStatus !== 'ACTIVE') throw new Error('signing journal table is not ACTIVE');
+      const hashKey = response.Table?.KeySchema?.find((item) => item.KeyType === 'HASH')?.AttributeName;
+      if (hashKey !== 'decisionKey') throw new Error('signing journal table partition key must be decisionKey');
+    },
+
+    async record(key, hash) {
+      validateDecision(key, hash);
+      try {
+        await client.send(new PutItemCommand({
+          TableName: tableName,
+          Item: {
+            decisionKey: { S: key },
+            hash: { S: hash.toLowerCase() },
+            signerAddress: { S: signerAddress },
+            recordedAt: { S: new Date().toISOString() },
+          },
+          ConditionExpression: 'attribute_not_exists(decisionKey) OR #decisionHash = :decisionHash',
+          ExpressionAttributeNames: { '#decisionHash': 'hash' },
+          ExpressionAttributeValues: { ':decisionHash': { S: hash.toLowerCase() } },
+        }));
+        return true;
+      } catch (error) {
+        if (error?.name === 'ConditionalCheckFailedException') {
+          throw new Error(`refusing equivocation for ${key}`);
+        }
+        throw error;
+      }
+    },
+  };
+};

--- a/MultX/signer/src/index.js
+++ b/MultX/signer/src/index.js
@@ -7,11 +7,11 @@ import { createDynamoDecisionJournal } from './dynamoJournal.js';
 import { createDecisionJournal } from './journal.js';
 import {
   assertLockEvent,
-  parseSignerPolicy,
   releaseMessageHash,
   resolvePolicy,
   validateAttestation,
 } from './policy.js';
+import { loadSignerPolicy } from './runtimeConfig.js';
 import { createSigningKey } from './signingKey.js';
 
 const requiredFile = (envName) => {
@@ -22,15 +22,10 @@ const requiredFile = (envName) => {
   return value;
 };
 
-const policyFile = process.env.SIGNER_POLICY_FILE;
-const policyJson = process.env.SIGNER_POLICY_JSON;
-if (policyFile && policyJson) throw new Error('configure signer policy file or JSON, never both');
-if (!policyFile && !policyJson) throw new Error('SIGNER_POLICY_FILE or SIGNER_POLICY_JSON is required');
-const policy = parseSignerPolicy(JSON.parse(
-  policyFile ? requiredFile('SIGNER_POLICY_FILE').toString('utf8') : policyJson,
-));
+const signingEnabled = process.env.SIGNER_RELEASE_SIGNING_ENABLED === 'true';
+const policy = loadSignerPolicy({ signingEnabled });
 const signer = await createSigningKey();
-if (policy.signerAddress && getAddress(policy.signerAddress) !== signer.address) {
+if (policy?.signerAddress && getAddress(policy.signerAddress) !== signer.address) {
   throw new Error(`policy signer ${policy.signerAddress} does not match key ${signer.address}`);
 }
 
@@ -61,7 +56,6 @@ if (journalBackend === 'dynamodb') {
   throw new Error('production signer requires SIGNER_JOURNAL_BACKEND=dynamodb');
 }
 
-const signingEnabled = process.env.SIGNER_RELEASE_SIGNING_ENABLED === 'true';
 if (!signingEnabled) console.log('[signer] release signing is disabled');
 
 const providers = new Map();

--- a/MultX/signer/src/index.js
+++ b/MultX/signer/src/index.js
@@ -1,6 +1,9 @@
-import fs from 'fs';
-import https from 'https';
-import { ethers } from 'ethers';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import { Contract, getAddress, getBytes, JsonRpcProvider, verifyMessage } from 'ethers';
+import { hasValidBearerToken, loadBearerToken } from './auth.js';
+import { createDynamoDecisionJournal } from './dynamoJournal.js';
 import { createDecisionJournal } from './journal.js';
 import {
   assertLockEvent,
@@ -9,6 +12,7 @@ import {
   resolvePolicy,
   validateAttestation,
 } from './policy.js';
+import { createSigningKey } from './signingKey.js';
 
 const requiredFile = (envName) => {
   const file = process.env[envName];
@@ -18,30 +22,60 @@ const requiredFile = (envName) => {
   return value;
 };
 
-const policy = parseSignerPolicy(JSON.parse(requiredFile('SIGNER_POLICY_FILE').toString('utf8')));
-const privateKey = requiredFile('SIGNER_PRIVATE_KEY_FILE').toString('utf8').trim();
-const wallet = new ethers.Wallet(privateKey);
-if (policy.signerAddress && ethers.getAddress(policy.signerAddress) !== wallet.address) {
-  throw new Error(`policy signer ${policy.signerAddress} does not match key ${wallet.address}`);
+const policyFile = process.env.SIGNER_POLICY_FILE;
+const policyJson = process.env.SIGNER_POLICY_JSON;
+if (policyFile && policyJson) throw new Error('configure signer policy file or JSON, never both');
+if (!policyFile && !policyJson) throw new Error('SIGNER_POLICY_FILE or SIGNER_POLICY_JSON is required');
+const policy = parseSignerPolicy(JSON.parse(
+  policyFile ? requiredFile('SIGNER_POLICY_FILE').toString('utf8') : policyJson,
+));
+const signer = await createSigningKey();
+if (policy.signerAddress && getAddress(policy.signerAddress) !== signer.address) {
+  throw new Error(`policy signer ${policy.signerAddress} does not match key ${signer.address}`);
 }
+
+if (signer.kind === 'kms') {
+  const challenge = getBytes(Buffer.from('MultX production signer transaction-free verification v1'));
+  const signature = await signer.signMessage(challenge);
+  if (verifyMessage(challenge, signature).toLowerCase() !== signer.address.toLowerCase()) {
+    throw new Error('transaction-free KMS verification recovered the wrong signer');
+  }
+  console.log(`[signer] transaction-free KMS verification passed for ${signer.address}`);
+}
+
+const journalBackend = process.env.SIGNER_JOURNAL_BACKEND ||
+  (process.env.NODE_ENV === 'production' ? 'dynamodb' : 'file');
+let journal;
+if (journalBackend === 'dynamodb') {
+  journal = createDynamoDecisionJournal({
+    tableName: process.env.SIGNER_DYNAMODB_TABLE,
+    signerAddress: signer.address,
+    region: process.env.AWS_REGION,
+  });
+  await journal.assertReady();
+} else if (journalBackend === 'file' && process.env.NODE_ENV !== 'production') {
+  journal = createDecisionJournal(
+    process.env.SIGNER_STATE_FILE || '/var/lib/multx-signer/signed-releases.jsonl',
+  );
+} else {
+  throw new Error('production signer requires SIGNER_JOURNAL_BACKEND=dynamodb');
+}
+
+const signingEnabled = process.env.SIGNER_RELEASE_SIGNING_ENABLED === 'true';
+if (!signingEnabled) console.log('[signer] release signing is disabled');
 
 const providers = new Map();
 const sourceContract = (source) => {
   const key = Number(source.chainId);
   if (!providers.has(key)) {
-    // Do not pin a static network here: getNetwork() must query the endpoint so
-    // a policy URL that is accidentally pointed at another chain fails closed.
-    const provider = new ethers.JsonRpcProvider(source.rpcUrl);
-    const contract = new ethers.Contract(source.bridgeAddress, [
+    const provider = new JsonRpcProvider(source.rpcUrl);
+    const contract = new Contract(source.bridgeAddress, [
       'event TokensLocked(bytes32 indexed txHash,address indexed token,address indexed user,uint256 amount,uint256 targetChain,uint256 nonce)',
     ], provider);
     providers.set(key, { provider, contract });
   }
   return providers.get(key);
 };
-
-const stateFile = process.env.SIGNER_STATE_FILE || '/var/lib/multx-signer/signed-releases.jsonl';
-const journal = createDecisionJournal(stateFile);
 
 let signingQueue = Promise.resolve();
 const serializeSigning = (fn) => {
@@ -53,7 +87,7 @@ const serializeSigning = (fn) => {
 const verifyAndSign = async (input) => {
   const attestation = validateAttestation(input);
   const { source } = resolvePolicy(policy, attestation);
-  const { provider, contract } = sourceContract(source);
+  const { provider, contract } = await sourceContract(source);
 
   const network = await provider.getNetwork();
   if (Number(network.chainId) !== attestation.sourceChain) throw new Error('source RPC chain ID mismatch');
@@ -76,10 +110,10 @@ const verifyAndSign = async (input) => {
   const hash = releaseMessageHash(attestation);
   const key = `${attestation.sourceChain}:${attestation.sourceNonce}`;
   return serializeSigning(async () => {
-    // Persist the decision before producing a signature. A crash can therefore
-    // withhold a signature, but can never erase the anti-equivocation decision.
-    journal.record(key, hash);
-    return wallet.signMessage(ethers.getBytes(hash));
+    // Persist the decision before producing a signature. A crash can withhold
+    // a signature but cannot erase or replace the anti-equivocation decision.
+    await journal.record(key, hash);
+    return signer.signMessage(getBytes(hash));
   });
 };
 
@@ -104,41 +138,76 @@ const readJson = (req) => new Promise((resolve, reject) => {
 
 const send = (res, status, body) => {
   const payload = JSON.stringify(body);
-  res.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) });
+  res.writeHead(status, {
+    'cache-control': 'no-store',
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(payload),
+  });
   res.end(payload);
 };
 
-const server = https.createServer({
-  cert: requiredFile('SIGNER_TLS_CERT_FILE'),
-  key: requiredFile('SIGNER_TLS_KEY_FILE'),
-  ca: requiredFile('SIGNER_CLIENT_CA_FILE'),
-  requestCert: true,
-  rejectUnauthorized: true,
-  minVersion: 'TLSv1.3',
-}, async (req, res) => {
+const transport = process.env.SIGNER_TRANSPORT || 'mtls';
+let bearerToken = null;
+let server;
+const handler = async (req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    return send(res, 200, { status: 'healthy', signingEnabled });
+  }
+
+  if (transport === 'proxy-http') {
+    if (String(req.headers['x-forwarded-proto'] || '').toLowerCase() !== 'https') {
+      return send(res, 403, { error: 'tls_proxy_required' });
+    }
+    if (!hasValidBearerToken(req.headers.authorization, bearerToken)) {
+      res.setHeader('www-authenticate', 'Bearer');
+      return send(res, 401, { error: 'unauthorized' });
+    }
+  }
+
   try {
-    if (req.method === 'GET' && req.url === '/health') return send(res, 200, { status: 'healthy' });
-    if (req.method === 'GET' && req.url === '/v1/identity') return send(res, 200, { address: wallet.address });
+    if (req.method === 'GET' && req.url === '/v1/identity') {
+      return send(res, 200, { address: signer.address });
+    }
     if (req.method === 'POST' && req.url === '/v1/sign-release') {
+      if (!signingEnabled) return send(res, 503, { error: 'signing_disabled' });
       const signature = await verifyAndSign(await readJson(req));
-      return send(res, 200, { address: wallet.address, signature });
+      return send(res, 200, { address: signer.address, signature });
     }
     return send(res, 404, { error: 'not_found' });
-  } catch (err) {
-    console.error(`[signer] request rejected: ${err.message}`);
+  } catch (error) {
+    console.error(`[signer] request rejected: ${error.message}`);
     return send(res, 400, { error: 'request_rejected' });
   }
-});
+};
+
+if (transport === 'proxy-http') {
+  if (process.env.SIGNER_BEHIND_TLS_PROXY !== 'true') {
+    throw new Error('proxy-http requires SIGNER_BEHIND_TLS_PROXY=true');
+  }
+  bearerToken = loadBearerToken();
+  server = http.createServer(handler);
+} else if (transport === 'mtls') {
+  server = https.createServer({
+    cert: requiredFile('SIGNER_TLS_CERT_FILE'),
+    key: requiredFile('SIGNER_TLS_KEY_FILE'),
+    ca: requiredFile('SIGNER_CLIENT_CA_FILE'),
+    requestCert: true,
+    rejectUnauthorized: true,
+    minVersion: 'TLSv1.3',
+  }, handler);
+} else {
+  throw new Error('SIGNER_TRANSPORT must be mtls or proxy-http');
+}
 
 server.headersTimeout = 10_000;
 server.requestTimeout = 15_000;
 server.keepAliveTimeout = 5_000;
 server.maxRequestsPerSocket = 100;
 
-const port = Number(process.env.SIGNER_PORT || 9443);
+const port = Number(process.env.SIGNER_PORT || (transport === 'proxy-http' ? 8080 : 9443));
 if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
   throw new Error('SIGNER_PORT must be an integer between 1 and 65535');
 }
 server.listen(port, '0.0.0.0', () => {
-  console.log(`[signer] listening on ${port}; address=${wallet.address}`);
+  console.log(`[signer] listening on ${port}; transport=${transport}; key=${signer.kind}; address=${signer.address}`);
 });

--- a/MultX/signer/src/kmsSigner.js
+++ b/MultX/signer/src/kmsSigner.js
@@ -1,0 +1,86 @@
+import { GetPublicKeyCommand, KMSClient, SignCommand } from '@aws-sdk/client-kms';
+import { getAddress, hashMessage, keccak256, recoverAddress } from 'ethers';
+
+const CURVE_N = BigInt('0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141');
+const HALF_N = CURVE_N >> 1n;
+const clients = new Map();
+
+const clientFor = (region) => {
+  const selected = region || process.env.AWS_REGION || 'us-east-1';
+  if (!clients.has(selected)) clients.set(selected, new KMSClient({ region: selected }));
+  return clients.get(selected);
+};
+
+const readDerLength = (bytes, offset) => {
+  const first = bytes[offset];
+  if (first === undefined) throw new Error('truncated DER length');
+  if (first < 0x80) return { length: first, next: offset + 1 };
+  const count = first & 0x7f;
+  if (count < 1 || count > 2 || offset + count >= bytes.length) {
+    throw new Error('unsupported DER length');
+  }
+  let length = 0;
+  for (let i = 0; i < count; i += 1) length = (length << 8) | bytes[offset + 1 + i];
+  return { length, next: offset + 1 + count };
+};
+
+const decodeInteger = (bytes, offset) => {
+  if (bytes[offset] !== 0x02) throw new Error('invalid DER integer');
+  const { length, next } = readDerLength(bytes, offset + 1);
+  const value = bytes.subarray(next, next + length);
+  if (value.length === 0 || next + length > bytes.length) throw new Error('truncated DER integer');
+  return { value: BigInt(`0x${Buffer.from(value).toString('hex') || '0'}`), next: next + length };
+};
+
+export const decodeKmsSignature = (input) => {
+  const bytes = Buffer.from(input);
+  if (bytes[0] !== 0x30) throw new Error('invalid DER signature sequence');
+  const sequence = readDerLength(bytes, 1);
+  if (sequence.next + sequence.length !== bytes.length) throw new Error('invalid DER signature length');
+  const r = decodeInteger(bytes, sequence.next);
+  const s = decodeInteger(bytes, r.next);
+  if (s.next !== bytes.length || r.value < 1n || s.value < 1n) {
+    throw new Error('invalid DER signature values');
+  }
+  return { r: r.value, s: s.value > HALF_N ? CURVE_N - s.value : s.value };
+};
+
+const word = (value) => value.toString(16).padStart(64, '0');
+
+export const kmsKeyAddress = async (keyId, { region, client } = {}) => {
+  const response = await (client || clientFor(region)).send(new GetPublicKeyCommand({ KeyId: keyId }));
+  if (!response.PublicKey) throw new Error('KMS GetPublicKey returned no public key');
+  if (response.KeySpec && response.KeySpec !== 'ECC_SECG_P256K1') {
+    throw new Error(`KMS key must use ECC_SECG_P256K1, received ${response.KeySpec}`);
+  }
+  if (response.KeyUsage && response.KeyUsage !== 'SIGN_VERIFY') {
+    throw new Error(`KMS key must use SIGN_VERIFY, received ${response.KeyUsage}`);
+  }
+  if (response.SigningAlgorithms && !response.SigningAlgorithms.includes('ECDSA_SHA_256')) {
+    throw new Error('KMS key does not support ECDSA_SHA_256');
+  }
+  const point = Buffer.from(response.PublicKey).subarray(-65);
+  if (point.length !== 65 || point[0] !== 0x04) {
+    throw new Error('KMS key is not an uncompressed secp256k1 key');
+  }
+  return getAddress(`0x${keccak256(point.subarray(1)).slice(-40)}`);
+};
+
+export const kmsSignMessage = async ({ keyId, message, expectedAddress, region, client }) => {
+  const digest = hashMessage(message);
+  const response = await (client || clientFor(region)).send(new SignCommand({
+    KeyId: keyId,
+    Message: Buffer.from(digest.slice(2), 'hex'),
+    MessageType: 'DIGEST',
+    SigningAlgorithm: 'ECDSA_SHA_256',
+  }));
+  if (!response.Signature) throw new Error('KMS Sign returned no signature');
+  const { r, s } = decodeKmsSignature(response.Signature);
+  for (const v of [27, 28]) {
+    const signature = `0x${word(r)}${word(s)}${v.toString(16)}`;
+    if (recoverAddress(digest, signature).toLowerCase() === expectedAddress.toLowerCase()) {
+      return signature;
+    }
+  }
+  throw new Error('KMS signature does not recover the expected signer address');
+};

--- a/MultX/signer/src/runtimeConfig.js
+++ b/MultX/signer/src/runtimeConfig.js
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import { parseSignerPolicy } from './policy.js';
+
+const readRequiredFile = (file, envName) => {
+  const value = fs.readFileSync(file);
+  if (value.length === 0) throw new Error(`${envName} is empty`);
+  return value;
+};
+
+export const loadSignerPolicy = ({
+  signingEnabled,
+  policyFile = process.env.SIGNER_POLICY_FILE,
+  policyJson = process.env.SIGNER_POLICY_JSON,
+} = {}) => {
+  if (policyFile && policyJson) {
+    throw new Error('configure signer policy file or JSON, never both');
+  }
+  if (!policyFile && !policyJson) {
+    if (!signingEnabled) return null;
+    throw new Error('SIGNER_POLICY_FILE or SIGNER_POLICY_JSON is required when signing is enabled');
+  }
+
+  const serialized = policyFile
+    ? readRequiredFile(policyFile, 'SIGNER_POLICY_FILE').toString('utf8')
+    : policyJson;
+  return parseSignerPolicy(JSON.parse(serialized));
+};

--- a/MultX/signer/src/signingKey.js
+++ b/MultX/signer/src/signingKey.js
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import { Wallet } from 'ethers';
+import { kmsKeyAddress, kmsSignMessage } from './kmsSigner.js';
+
+const readRequiredFile = (path, label) => {
+  if (!path) throw new Error(`${label} is required`);
+  const value = fs.readFileSync(path, 'utf8').trim();
+  if (!value) throw new Error(`${label} is empty`);
+  return value;
+};
+
+export const createSigningKey = async ({ env = process.env } = {}) => {
+  const kmsKeyArn = env.SIGNER_KMS_KEY_ARN;
+  const privateKeyFile = env.SIGNER_PRIVATE_KEY_FILE;
+  if (kmsKeyArn && privateKeyFile) throw new Error('configure KMS or a key file, never both');
+
+  if (kmsKeyArn) {
+    const address = await kmsKeyAddress(kmsKeyArn, { region: env.AWS_REGION });
+    return {
+      kind: 'kms',
+      address,
+      async signMessage(message) {
+        return kmsSignMessage({
+          keyId: kmsKeyArn,
+          message,
+          expectedAddress: address,
+          region: env.AWS_REGION,
+        });
+      },
+    };
+  }
+
+  if (env.NODE_ENV === 'production') {
+    throw new Error('production signer requires SIGNER_KMS_KEY_ARN');
+  }
+  const wallet = new Wallet(readRequiredFile(privateKeyFile, 'SIGNER_PRIVATE_KEY_FILE'));
+  return { kind: 'file', address: wallet.address, signMessage: (message) => wallet.signMessage(message) };
+};

--- a/MultX/signer/test/auth.test.js
+++ b/MultX/signer/test/auth.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { hasValidBearerToken, loadBearerToken } from '../src/auth.js';
+
+const token = 'a-secure-test-token-that-is-at-least-32-characters';
+
+test('accepts only an exact Bearer token', () => {
+  assert.equal(hasValidBearerToken(`Bearer ${token}`, token), true);
+  assert.equal(hasValidBearerToken(`bearer ${token}`, token), false);
+  assert.equal(hasValidBearerToken(`Bearer ${token}x`, token), false);
+  assert.equal(hasValidBearerToken('', token), false);
+});
+
+test('requires one bounded token source', () => {
+  assert.equal(loadBearerToken({ env: { SIGNER_BEARER_TOKEN: token } }), token);
+  assert.throws(() => loadBearerToken({ env: {} }), /required/);
+  assert.throws(() => loadBearerToken({ env: { SIGNER_BEARER_TOKEN: 'short' } }), /32 to 512/);
+  assert.throws(() => loadBearerToken({
+    env: { SIGNER_BEARER_TOKEN: token, SIGNER_BEARER_TOKEN_FILE: '/tmp/token' },
+  }), /never both/);
+});

--- a/MultX/signer/test/dynamoJournal.test.js
+++ b/MultX/signer/test/dynamoJournal.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DescribeTableCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { createDynamoDecisionJournal } from '../src/dynamoJournal.js';
+
+const address = '0x1111111111111111111111111111111111111111';
+const hash = `0x${'22'.repeat(32)}`;
+
+test('checks the table schema and atomically records a decision', async () => {
+  const commands = [];
+  const client = {
+    async send(command) {
+      commands.push(command);
+      if (command instanceof DescribeTableCommand) {
+        return { Table: { TableStatus: 'ACTIVE', KeySchema: [{ AttributeName: 'decisionKey', KeyType: 'HASH' }] } };
+      }
+      return {};
+    },
+  };
+  const journal = createDynamoDecisionJournal({ tableName: 'decisions', signerAddress: address, client });
+  await journal.assertReady();
+  await journal.record('9005:7', hash);
+
+  assert.equal(commands.length, 2);
+  assert.equal(commands[1] instanceof PutItemCommand, true);
+  assert.equal(commands[1].input.Item.decisionKey.S, '9005:7');
+  assert.equal(commands[1].input.Item.hash.S, hash);
+  assert.match(commands[1].input.ConditionExpression, /attribute_not_exists/);
+});
+
+test('fails closed on a conditional equivocation conflict', async () => {
+  const client = { async send() { throw Object.assign(new Error('conflict'), { name: 'ConditionalCheckFailedException' }); } };
+  const journal = createDynamoDecisionJournal({ tableName: 'decisions', signerAddress: address, client });
+  await assert.rejects(() => journal.record('9005:7', hash), /refusing equivocation/);
+});
+
+test('rejects malformed decisions before calling DynamoDB', async () => {
+  let called = false;
+  const client = { async send() { called = true; } };
+  const journal = createDynamoDecisionJournal({ tableName: 'decisions', signerAddress: address, client });
+  await assert.rejects(() => journal.record('bad', hash), /invalid signing journal decision/);
+  assert.equal(called, false);
+});

--- a/MultX/signer/test/kmsSigner.test.js
+++ b/MultX/signer/test/kmsSigner.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { decodeKmsSignature, kmsKeyAddress } from '../src/kmsSigner.js';
+
+test('decodes a minimal valid DER ECDSA signature', () => {
+  const decoded = decodeKmsSignature(Buffer.from('3006020101020102', 'hex'));
+  assert.equal(decoded.r, 1n);
+  assert.equal(decoded.s, 2n);
+});
+
+test('rejects malformed or zero DER values', () => {
+  assert.throws(() => decodeKmsSignature(Buffer.from('0000', 'hex')), /sequence/);
+  assert.throws(() => decodeKmsSignature(Buffer.from('3006020100020102', 'hex')), /values/);
+});
+
+test('rejects a KMS key with the wrong cryptographic specification', async () => {
+  const client = { async send() { return { PublicKey: Buffer.from([1]), KeySpec: 'RSA_2048' }; } };
+  await assert.rejects(() => kmsKeyAddress('test-key', { client }), /ECC_SECG_P256K1/);
+});

--- a/MultX/signer/test/runtimeConfig.test.js
+++ b/MultX/signer/test/runtimeConfig.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { loadSignerPolicy } from '../src/runtimeConfig.js';
+
+test('disabled signer can start without a bridge policy', () => {
+  assert.equal(loadSignerPolicy({ signingEnabled: false }), null);
+});
+
+test('enabled signer fails closed without a bridge policy', () => {
+  assert.throws(
+    () => loadSignerPolicy({ signingEnabled: true }),
+    /required when signing is enabled/,
+  );
+});
+
+test('policy sources remain mutually exclusive while disabled', () => {
+  assert.throws(
+    () => loadSignerPolicy({
+      signingEnabled: false,
+      policyFile: 'policy.json',
+      policyJson: '{}',
+    }),
+    /never both/,
+  );
+});


### PR DESCRIPTION
## Summary

- adds the disabled AWS Fargate production signer candidate using one non-exportable KMS key per service
- adds durable DynamoDB conditional anti-equivocation state
- adds private TLS-proxy + constant-time bearer authentication and API client support
- retains independent RPC chain, confirmation, policy, and exact lock-event verification before any signature
- documents exact minimum runtime permissions and activation gates

## Verification

- signer: 19/19 tests passed; npm audit reports 0 vulnerabilities
- API: 19/19 tests passed; npm audit reports 0 vulnerabilities
- live transaction-free KMS signature/recovery passed against all seven configured keys
- immutable candidate image built and ECR scan completed with zero findings

## Safety boundary

`SIGNER_RELEASE_SIGNING_ENABLED` defaults to false. While false, `/v1/sign-release` returns HTTP 503. This PR does not deploy endpoints, change contracts, rotate validators, enable MultX, or submit a transaction. Production provisioning and resource mappings remain private in `KaJLabs/Lithosphere-Production-Infra`.